### PR TITLE
fix(security): harden untrusted-input boundaries across daemon and CLI

### DIFF
--- a/crates/makiatto-cli/src/health.rs
+++ b/crates/makiatto-cli/src/health.rs
@@ -223,7 +223,39 @@ async fn check_node_health(
     expected_hashes: &HashSet<String>,
     key_path: Option<&PathBuf>,
 ) -> NodeHealth {
-    let ssh = SshSession::new(&machine.ssh_target, machine.port, key_path).unwrap();
+    let ssh = match SshSession::new(&machine.ssh_target, machine.port, key_path) {
+        Ok(ssh) => ssh,
+        Err(e) => {
+            // Surface the node as unreachable rather than panicking the task: a
+            // swallowed panic here would shrink the result set and let the
+            // remaining nodes look like a healthy consensus.
+            return NodeHealth {
+                name: machine.name.clone(),
+                consensus: ConsensusStatus {
+                    healthy: false,
+                    leader: None,
+                    term: None,
+                    error: Some(format!("SSH connection failed: {e}")),
+                },
+                system: SystemStatus {
+                    healthy: false,
+                    memory_percent: None,
+                    disk_percent: None,
+                    load_average: None,
+                    error: Some("unreachable".to_string()),
+                },
+                dns: None,
+                web: vec![],
+                file_sync: FileSyncStatus {
+                    expected: 0,
+                    present: 0,
+                    missing: vec![],
+                    error: Some("unreachable".to_string()),
+                },
+                version: None,
+            };
+        }
+    };
 
     let consensus = check_consensus(&ssh).await;
     let system = check_system_health(&ssh).await;
@@ -275,7 +307,8 @@ async fn check_consensus(ssh: &SshSession) -> ConsensusStatus {
 
     match tokio::task::spawn_blocking(move || {
         let query = "SELECT node_name, role, term FROM cluster_leadership LIMIT 1";
-        let cmd = format!("sqlite3 /var/makiatto/cluster.db -separator '|' \"{query}\"");
+        let cmd =
+            format!("sudo -u makiatto sqlite3 /var/makiatto/cluster.db -separator '|' \"{query}\"");
 
         let output = ssh.exec(&cmd)?;
         let line = output.lines().next().unwrap_or("");

--- a/crates/makiatto-cli/src/machine.rs
+++ b/crates/makiatto-cli/src/machine.rs
@@ -575,6 +575,9 @@ pub fn remove_machine(request: &RemoveMachine, profile: &mut Profile) -> Result<
 
     ui::action("Removing configuration files");
     let _ = ssh.exec("sudo rm -rf /etc/makiatto");
+    // also remove the standalone config, which holds the WireGuard private key
+    let _ = ssh.exec("sudo rm -f /etc/makiatto.toml");
+    let _ = ssh.exec("sudo rm -f /etc/sudoers.d/makiatto");
 
     ui::action("Removing makiatto user");
     let _ = ssh.exec("sudo userdel -r makiatto 2>/dev/null");

--- a/crates/makiatto-cli/src/machine/corrosion.rs
+++ b/crates/makiatto-cli/src/machine/corrosion.rs
@@ -1,7 +1,42 @@
 #![allow(dead_code)]
 use miette::{IntoDiagnostic, Result, miette};
+use serde::Serialize;
+use serde_json::Value;
 
 use crate::{config::Machine, ssh::SshSession};
+
+/// A SQL statement for the Corrosion `/v1/transactions` API.
+///
+/// Serialises to Corrosion's wire format: a bare string for [`Statement::Simple`]
+/// or `[sql, [params]]` for [`Statement::WithParams`]. Always use the
+/// parameterised form for non-constant values — the statement is gossiped to and
+/// executed on every node in the cluster.
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum Statement {
+    Simple(String),
+    WithParams(String, Vec<Value>),
+}
+
+impl Statement {
+    /// Build a parameterised statement.
+    #[must_use]
+    pub fn with_params(sql: impl Into<String>, params: Vec<Value>) -> Self {
+        Self::WithParams(sql.into(), params)
+    }
+}
+
+impl From<String> for Statement {
+    fn from(sql: String) -> Self {
+        Self::Simple(sql)
+    }
+}
+
+impl From<&str> for Statement {
+    fn from(sql: &str) -> Self {
+        Self::Simple(sql.to_string())
+    }
+}
 
 /// Represents a peer from the database
 #[derive(Debug, Clone)]
@@ -25,18 +60,20 @@ pub fn insert_peer(ssh: &SshSession, machine: &Machine) -> Result<()> {
     let ipv6_value = machine
         .ipv6
         .as_ref()
-        .map_or_else(|| "NULL".to_string(), |s| format!("'{s}'"));
+        .map_or(Value::Null, |s| Value::String(s.to_string()));
 
-    let sql = format!(
-        "INSERT INTO peers (name, latitude, longitude, ipv4, ipv6, wg_public_key, wg_address, is_nameserver, is_external) VALUES ('{}', {}, {}, '{}', {}, '{}', '{}', {}, 0)",
-        machine.name,
-        latitude,
-        longitude,
-        machine.ipv4,
-        ipv6_value,
-        machine.wg_public_key,
-        machine.wg_address,
-        u8::from(machine.is_nameserver)
+    let sql = Statement::with_params(
+        "INSERT INTO peers (name, latitude, longitude, ipv4, ipv6, wg_public_key, wg_address, is_nameserver, is_external) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)",
+        vec![
+            Value::from(machine.name.as_ref()),
+            Value::from(latitude),
+            Value::from(longitude),
+            Value::from(machine.ipv4.as_ref()),
+            ipv6_value,
+            Value::from(machine.wg_public_key.as_ref()),
+            Value::from(machine.wg_address.as_ref()),
+            Value::from(u8::from(machine.is_nameserver)),
+        ],
     );
 
     execute_transactions(ssh, &[sql])?;
@@ -49,7 +86,10 @@ pub fn insert_peer(ssh: &SshSession, machine: &Machine) -> Result<()> {
 /// # Errors
 /// Returns an error if the SSH command fails or if the database operation fails
 pub fn delete_peer(ssh: &SshSession, name: &str) -> Result<()> {
-    let sql = format!("DELETE FROM peers WHERE name = '{name}'");
+    let sql = Statement::with_params(
+        "DELETE FROM peers WHERE name = ?",
+        vec![Value::from(name)],
+    );
     execute_transactions(ssh, &[sql])?;
     Ok(())
 }
@@ -159,10 +199,24 @@ pub fn query_peers(ssh: &SshSession) -> Result<Vec<Peer>> {
 /// # Errors
 /// Returns an error if the SSH command fails, database query fails, or if the data format is invalid
 pub fn query_peer(ssh: &SshSession, name: &str) -> Result<Option<Peer>> {
+    // `name` is interpolated into a shell command below, so it must be a safe
+    // identifier. Node/peer names are validated as alphanumeric/_/- elsewhere;
+    // reject anything else here to avoid shell or SQL injection via, e.g., a
+    // malicious remote config.
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err(miette!("Invalid peer name: {name:?}"));
+    }
+
     let sql = format!(
         "SELECT wg_public_key, wg_address, ipv4, ipv6, latitude, longitude FROM peers WHERE name = '{name}'",
     );
-    let cmd = format!("sqlite3 /var/makiatto/cluster.db \"{sql}\"");
+    // read as the makiatto user for consistency with the other DB reads (the
+    // cluster.db is owned by makiatto and not necessarily world-readable)
+    let cmd = format!("sudo -u makiatto sqlite3 /var/makiatto/cluster.db \"{sql}\"");
 
     let output = ssh
         .exec(&cmd)
@@ -205,17 +259,22 @@ pub fn query_peer(ssh: &SshSession, name: &str) -> Result<Option<Peer>> {
 ///
 /// # Errors
 /// Returns an error if the HTTP request fails or the API returns an error
-pub fn execute_transactions(ssh: &SshSession, sqls: &[String]) -> Result<()> {
-    if sqls.is_empty() {
+pub fn execute_transactions(ssh: &SshSession, statements: &[Statement]) -> Result<()> {
+    if statements.is_empty() {
         return Ok(());
     }
 
-    let json_payload = serde_json::to_string(sqls).into_diagnostic()?;
-    // need to escape backslashes and quotes for passing through SSH
-    let escaped_payload = json_payload.replace('\\', "\\\\").replace('"', "\\\"");
+    let json_payload = serde_json::to_string(statements).into_diagnostic()?;
 
+    // Pass the JSON to curl on stdin via a quoted heredoc. Because the heredoc
+    // delimiter is single-quoted ('PAYLOAD'), the remote shell performs NO
+    // expansion on the body — $(...), backticks and ${...} are all inert — so a
+    // hostile value in the payload cannot inject shell commands. `to_string`
+    // emits a single line (newlines inside values are escaped as \n), so the
+    // body can never collide with the delimiter line.
     let cmd = format!(
-        "curl -s -X POST -H 'Content-Type: application/json' -d \"{escaped_payload}\" http://127.0.0.1:8181/v1/transactions",
+        "curl -s -X POST -H 'Content-Type: application/json' --data-binary @- \
+         http://127.0.0.1:8181/v1/transactions <<'MAKIATTO_TXN_EOF'\n{json_payload}\nMAKIATTO_TXN_EOF",
     );
 
     let response = ssh

--- a/crates/makiatto-cli/src/machine/corrosion.rs
+++ b/crates/makiatto-cli/src/machine/corrosion.rs
@@ -86,10 +86,7 @@ pub fn insert_peer(ssh: &SshSession, machine: &Machine) -> Result<()> {
 /// # Errors
 /// Returns an error if the SSH command fails or if the database operation fails
 pub fn delete_peer(ssh: &SshSession, name: &str) -> Result<()> {
-    let sql = Statement::with_params(
-        "DELETE FROM peers WHERE name = ?",
-        vec![Value::from(name)],
-    );
+    let sql = Statement::with_params("DELETE FROM peers WHERE name = ?", vec![Value::from(name)]);
     execute_transactions(ssh, &[sql])?;
     Ok(())
 }

--- a/crates/makiatto-cli/src/machine/provision.rs
+++ b/crates/makiatto-cli/src/machine/provision.rs
@@ -73,22 +73,28 @@ fn create_makiatto_user(ssh: &SshSession) -> Result<()> {
     ssh.exec("sudo usermod -a -G systemd-journal makiatto")?;
 
     ui::action("Setting up passwordless sudo permissions");
-    // The daemon (running as `makiatto`) only ever needs to manage its WireGuard
-    // interface and routes at runtime. Constrain NOPASSWD to exactly those `ip`
-    // subcommands instead of granting blanket access to chmod/chown/mkdir/setcap/
-    // systemctl on any path (which would be equivalent to full root). Everything
-    // else (provisioning, upgrades, restarts) runs as the SSH user with its own
-    // interactive sudo.
     let sudoers_cmd = formatdoc! {r"
         sudo tee /etc/sudoers.d/makiatto > /dev/null << 'EOF'
-        makiatto ALL=(ALL) NOPASSWD: /usr/sbin/ip link set * up, /usr/sbin/ip route add *, /usr/sbin/ip route del *, /usr/bin/ip link set * up, /usr/bin/ip route add *, /usr/bin/ip route del *
+        {rule}
         EOF
         sudo chmod 440 /etc/sudoers.d/makiatto
-    "};
+    ",
+        rule = MAKIATTO_SUDOERS_RULE,
+    };
     ssh.exec(&sudoers_cmd)?;
 
     Ok(())
 }
+
+/// The NOPASSWD sudoers rule installed for the `makiatto` daemon user.
+///
+/// The daemon (running as `makiatto`) only ever needs to manage its `WireGuard`
+/// interface and routes at runtime. We constrain NOPASSWD to exactly those `ip`
+/// subcommands rather than granting blanket access to chmod/chown/mkdir/setcap/
+/// systemctl on any path (which would be equivalent to full root). Everything
+/// else (provisioning, upgrades, restarts) runs as the SSH user with its own
+/// interactive sudo.
+const MAKIATTO_SUDOERS_RULE: &str = "makiatto ALL=(ALL) NOPASSWD: /usr/sbin/ip link set * up, /usr/sbin/ip route add *, /usr/sbin/ip route del *, /usr/bin/ip link set * up, /usr/bin/ip route add *, /usr/bin/ip route del *";
 
 pub fn install_makiatto_binary(ssh: &SshSession, binary_path: Option<&PathBuf>) -> Result<()> {
     ui::status("Installing makiatto binary...");
@@ -567,4 +573,27 @@ fn retrieve_geolocation(ssh: &SshSession) -> Result<GeoData> {
     }
 
     Ok(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MAKIATTO_SUDOERS_RULE;
+
+    #[test]
+    fn sudoers_rule_is_constrained_to_ip() {
+        // must only grant the specific `ip` subcommands the daemon needs
+        assert!(MAKIATTO_SUDOERS_RULE.contains("NOPASSWD:"));
+        assert!(MAKIATTO_SUDOERS_RULE.contains("ip route add"));
+        assert!(MAKIATTO_SUDOERS_RULE.contains("ip route del"));
+        assert!(MAKIATTO_SUDOERS_RULE.contains("ip link set"));
+
+        // must NOT grant the previously over-broad blanket binaries (which with
+        // no argument constraints were equivalent to full root)
+        for forbidden in ["chmod", "chown", "mkdir", "setcap", "systemctl"] {
+            assert!(
+                !MAKIATTO_SUDOERS_RULE.contains(forbidden),
+                "sudoers rule must not grant unconstrained {forbidden}"
+            );
+        }
+    }
 }

--- a/crates/makiatto-cli/src/machine/provision.rs
+++ b/crates/makiatto-cli/src/machine/provision.rs
@@ -73,10 +73,17 @@ fn create_makiatto_user(ssh: &SshSession) -> Result<()> {
     ssh.exec("sudo usermod -a -G systemd-journal makiatto")?;
 
     ui::action("Setting up passwordless sudo permissions");
+    // The daemon (running as `makiatto`) only ever needs to manage its WireGuard
+    // interface and routes at runtime. Constrain NOPASSWD to exactly those `ip`
+    // subcommands instead of granting blanket access to chmod/chown/mkdir/setcap/
+    // systemctl on any path (which would be equivalent to full root). Everything
+    // else (provisioning, upgrades, restarts) runs as the SSH user with its own
+    // interactive sudo.
     let sudoers_cmd = formatdoc! {r"
         sudo tee /etc/sudoers.d/makiatto > /dev/null << 'EOF'
-        makiatto ALL=(ALL) NOPASSWD: /usr/bin/systemctl, /usr/sbin/setcap, /usr/bin/mkdir, /usr/bin/chown, /usr/bin/chmod, /usr/bin/ip, /usr/sbin/ip
+        makiatto ALL=(ALL) NOPASSWD: /usr/sbin/ip link set * up, /usr/sbin/ip route add *, /usr/sbin/ip route del *, /usr/bin/ip link set * up, /usr/bin/ip route add *, /usr/bin/ip route del *
         EOF
+        sudo chmod 440 /etc/sudoers.d/makiatto
     "};
     ssh.exec(&sudoers_cmd)?;
 
@@ -358,6 +365,8 @@ fn create_daemon_config(
     };
     ssh.exec(&write_config_cmd)?;
     ssh.exec("sudo chown makiatto:makiatto /etc/makiatto.toml")?;
+    // the config holds the WireGuard private key, so it must not be world-readable
+    ssh.exec("sudo chmod 600 /etc/makiatto.toml")?;
 
     Ok(())
 }
@@ -504,11 +513,13 @@ fn retrieve_geolocation(ssh: &SshSession) -> Result<GeoData> {
     match ipv4_result {
         Ok(ipv4) => {
             let ipv4 = ipv4.trim();
-            if !ipv4.is_empty() && !ipv4.contains("error") && ipv4.contains('.') {
+            // validate it actually parses as an IPv4 address rather than just
+            // "looks like one", so a proxy error page can't end up stored as an IP
+            if ipv4.parse::<std::net::Ipv4Addr>().is_ok() {
                 ui::info(&format!("Fetched IPv4: {ipv4}"));
                 data.ipv4 = Arc::from(ipv4);
             } else {
-                return Err(miette::miette!("Could not fetch IPv4 address"));
+                return Err(miette::miette!("Could not fetch a valid IPv4 address"));
             }
         }
         Err(_) => {
@@ -523,7 +534,7 @@ fn retrieve_geolocation(ssh: &SshSession) -> Result<GeoData> {
     match ipv6_result {
         Ok(ipv6) => {
             let ipv6 = ipv6.trim();
-            if !ipv6.is_empty() && !ipv6.contains("error") && ipv6.contains(':') {
+            if ipv6.parse::<std::net::Ipv6Addr>().is_ok() {
                 ui::info(&format!("Fetched IPv6: {ipv6}"));
                 data.ipv6 = Some(Arc::from(ipv6));
             }

--- a/crates/makiatto-cli/src/peer.rs
+++ b/crates/makiatto-cli/src/peer.rs
@@ -140,9 +140,14 @@ pub fn add_external_peer(request: &AddExternalPeer, profile: &Profile) -> Result
     ui::field("Endpoint", &request.endpoint);
 
     // Insert into peers table with is_external = 1
-    let sql = format!(
-        "INSERT INTO peers (name, latitude, longitude, ipv4, ipv6, wg_public_key, wg_address, is_nameserver, is_external) VALUES ('{}', 0.0, 0.0, '{}', NULL, '{}', '{}', 0, 1)",
-        request.name, request.endpoint, request.wg_pubkey, wg_address,
+    let sql = corrosion::Statement::with_params(
+        "INSERT INTO peers (name, latitude, longitude, ipv4, ipv6, wg_public_key, wg_address, is_nameserver, is_external) VALUES (?, 0.0, 0.0, ?, NULL, ?, ?, 0, 1)",
+        vec![
+            serde_json::json!(request.name),
+            serde_json::json!(request.endpoint),
+            serde_json::json!(request.wg_pubkey),
+            serde_json::json!(wg_address),
+        ],
     );
 
     corrosion::execute_transactions(&ssh, &[sql])?;

--- a/crates/makiatto-cli/src/ssh.rs
+++ b/crates/makiatto-cli/src/ssh.rs
@@ -435,7 +435,11 @@ pub(crate) fn parse_ssh_target(target: &str) -> Result<(String, String, Option<u
         let port = match after.strip_prefix(':') {
             Some(p) => Some(p.parse::<u16>().map_err(|_| miette!("Invalid port: {p}"))?),
             None if after.is_empty() => None,
-            None => return Err(miette!("Unexpected characters after IPv6 address: {after:?}")),
+            None => {
+                return Err(miette!(
+                    "Unexpected characters after IPv6 address: {after:?}"
+                ));
+            }
         };
         (addr.to_string(), port)
     } else if let Some((h, p)) = host_port.rsplit_once(':')

--- a/crates/makiatto-cli/src/ssh.rs
+++ b/crates/makiatto-cli/src/ssh.rs
@@ -459,16 +459,27 @@ pub(crate) fn parse_ssh_target(target: &str) -> Result<(String, String, Option<u
     Ok((user.to_string(), host, port))
 }
 
+/// Resolve the `known_hosts` file path.
+///
+/// Honours the `MAKIATTO_KNOWN_HOSTS` environment variable (useful for pointing
+/// at a non-default file, and for test isolation); otherwise falls back to
+/// `~/.ssh/known_hosts`.
+fn known_hosts_path() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("MAKIATTO_KNOWN_HOSTS") {
+        return Some(PathBuf::from(path));
+    }
+    dirs::home_dir().map(|home| home.join(".ssh").join("known_hosts"))
+}
+
 /// Verify the server's host key against `~/.ssh/known_hosts`, trusting it on
 /// first use (TOFU). A mismatch is treated as a potential machine-in-the-middle
 /// and aborts the connection before any credentials are sent.
 fn verify_host_key(session: &Session, host: &str, port: u16) -> Result<()> {
-    let Some(home) = dirs::home_dir() else {
+    let Some(kh_path) = known_hosts_path() else {
         return Err(miette!(
-            "Cannot determine home directory for host key verification"
+            "Cannot determine known_hosts location for host key verification"
         ));
     };
-    let kh_path = home.join(".ssh").join("known_hosts");
 
     let mut known_hosts = session
         .known_hosts()
@@ -711,5 +722,20 @@ mod tests {
     #[test]
     fn test_known_host_line_unknown_type_is_rejected() {
         assert!(known_host_line("h", 22, b"abc", HostKeyType::Unknown).is_none());
+    }
+
+    #[test]
+    fn test_known_hosts_path_honours_env_override() {
+        // SAFETY: single-threaded test; restores the previous value before exit.
+        let prev = std::env::var("MAKIATTO_KNOWN_HOSTS").ok();
+        unsafe { std::env::set_var("MAKIATTO_KNOWN_HOSTS", "/tmp/custom_known_hosts") };
+        assert_eq!(
+            known_hosts_path(),
+            Some(PathBuf::from("/tmp/custom_known_hosts"))
+        );
+        match prev {
+            Some(v) => unsafe { std::env::set_var("MAKIATTO_KNOWN_HOSTS", v) },
+            None => unsafe { std::env::remove_var("MAKIATTO_KNOWN_HOSTS") },
+        }
     }
 }

--- a/crates/makiatto-cli/src/ssh.rs
+++ b/crates/makiatto-cli/src/ssh.rs
@@ -130,11 +130,9 @@ impl SshSession {
     pub fn exec_stream(&self, command: &str) -> Result<i32> {
         // Feed the sudo password over the (encrypted) channel stdin via `sudo -S`
         // rather than `echo '{pw}' |`, which would leak it into the remote
-        // process list. `-p ''` suppresses the prompt text.
-        let (command, sudo_password) = if let Some(password) = &self.password
-            && let Some(rest) = command.strip_prefix("sudo ")
-        {
-            (format!("sudo -S -p '' {rest}"), Some(password.clone()))
+        // process list.
+        let (command, sudo_password) = if self.password.is_some() && command.starts_with("sudo ") {
+            (wrap_sudo_command(command), self.password.clone())
         } else {
             (command.to_string(), None)
         };
@@ -409,11 +407,9 @@ impl SshSession {
         password: &str,
         timeout: Option<Duration>,
     ) -> Result<String> {
-        // strip the caller's leading `sudo ` so we don't end up with `sudo sudo`,
-        // then provide our own `sudo -S` and feed the password over the encrypted
+        // provide our own `sudo -S` and feed the password over the encrypted
         // channel stdin (never via the remote process arguments)
-        let inner = command.strip_prefix("sudo ").unwrap_or(command);
-        let sudo_command = format!("sudo -S -p '' {inner}");
+        let sudo_command = wrap_sudo_command(command);
         self.execute_command_raw_with_stdin(&sudo_command, Some(&format!("{password}\n")), timeout)
     }
 }
@@ -507,6 +503,44 @@ fn verify_host_key(session: &Session, host: &str, port: u16) -> Result<()> {
     }
 }
 
+/// Build the command to run under `sudo -S` (password supplied on stdin).
+///
+/// Strips a single leading `sudo ` so we never produce `sudo sudo …`, and uses
+/// `-p ''` to suppress the prompt. Note that the leading `sudo ` of a *compound*
+/// command (`sudo a && sudo b`) is all that is rewritten — the password is fed
+/// once, to the first `sudo -S`.
+fn wrap_sudo_command(command: &str) -> String {
+    let inner = command.strip_prefix("sudo ").unwrap_or(command);
+    format!("sudo -S -p '' {inner}")
+}
+
+/// Format an OpenSSH `known_hosts` line (without trailing newline) for a host key.
+///
+/// Returns `None` for an unknown key type that cannot be recorded. Non-default
+/// ports use the OpenSSH `[host]:port` form.
+fn known_host_line(host: &str, port: u16, key: &[u8], key_type: HostKeyType) -> Option<String> {
+    let key_type_str = match key_type {
+        HostKeyType::Rsa => "ssh-rsa",
+        HostKeyType::Dss => "ssh-dss",
+        HostKeyType::Ecdsa256 => "ecdsa-sha2-nistp256",
+        HostKeyType::Ecdsa384 => "ecdsa-sha2-nistp384",
+        HostKeyType::Ecdsa521 => "ecdsa-sha2-nistp521",
+        HostKeyType::Ed25519 => "ssh-ed25519",
+        HostKeyType::Unknown => return None,
+    };
+
+    let host_field = if port == 22 {
+        host.to_string()
+    } else {
+        format!("[{host}]:{port}")
+    };
+
+    Some(format!(
+        "{host_field} {key_type_str} {}",
+        STANDARD.encode(key)
+    ))
+}
+
 /// Append a host key to `known_hosts` in OpenSSH format (used for trust-on-first-use).
 fn append_known_host(
     path: &Path,
@@ -515,26 +549,8 @@ fn append_known_host(
     key: &[u8],
     key_type: HostKeyType,
 ) -> Result<()> {
-    let key_type_str = match key_type {
-        HostKeyType::Rsa => "ssh-rsa",
-        HostKeyType::Dss => "ssh-dss",
-        HostKeyType::Ecdsa256 => "ecdsa-sha2-nistp256",
-        HostKeyType::Ecdsa384 => "ecdsa-sha2-nistp384",
-        HostKeyType::Ecdsa521 => "ecdsa-sha2-nistp521",
-        HostKeyType::Ed25519 => "ssh-ed25519",
-        HostKeyType::Unknown => {
-            return Err(miette!("Unknown host key type; refusing to record it"));
-        }
-    };
-
-    // OpenSSH represents non-default ports as [host]:port
-    let host_field = if port == 22 {
-        host.to_string()
-    } else {
-        format!("[{host}]:{port}")
-    };
-
-    let line = format!("{host_field} {key_type_str} {}\n", STANDARD.encode(key));
+    let line = known_host_line(host, port, key, key_type)
+        .ok_or_else(|| miette!("Unknown host key type; refusing to record it"))?;
 
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
@@ -547,7 +563,7 @@ fn append_known_host(
         .open(path)
         .map_err(|e| miette!("Failed to open {}: {e}", path.display()))?;
 
-    file.write_all(line.as_bytes())
+    file.write_all(format!("{line}\n").as_bytes())
         .map_err(|e| miette!("Failed to write to {}: {e}", path.display()))?;
 
     Ok(())
@@ -652,5 +668,48 @@ mod tests {
         assert!(parse_ssh_target("@host").is_err());
         assert!(parse_ssh_target("user@").is_err());
         assert!(parse_ssh_target("user@host:notaport").is_err());
+    }
+
+    #[test]
+    fn test_wrap_sudo_command_strips_leading_sudo() {
+        // no double sudo: a leading `sudo ` is stripped before our `sudo -S`
+        assert_eq!(
+            wrap_sudo_command("sudo systemctl restart makiatto"),
+            "sudo -S -p '' systemctl restart makiatto"
+        );
+    }
+
+    #[test]
+    fn test_wrap_sudo_command_wraps_bare_command() {
+        // used by the sudo probe (`true`) and any non-sudo-prefixed command
+        assert_eq!(wrap_sudo_command("true"), "sudo -S -p '' true");
+    }
+
+    #[test]
+    fn test_wrap_sudo_command_only_first_sudo_in_compound() {
+        // documents the known limitation: only the leading sudo is rewritten;
+        // the second relies on sudo's credential cache
+        assert_eq!(
+            wrap_sudo_command("sudo apt update && sudo apt install -y x"),
+            "sudo -S -p '' apt update && sudo apt install -y x"
+        );
+    }
+
+    #[test]
+    fn test_known_host_line_default_port() {
+        let line = known_host_line("example.com", 22, b"\x00\x01\x02", HostKeyType::Rsa).unwrap();
+        assert_eq!(line, "example.com ssh-rsa AAEC");
+    }
+
+    #[test]
+    fn test_known_host_line_custom_port_is_bracketed() {
+        let line =
+            known_host_line("10.0.0.1", 2222, b"\x00\x01\x02", HostKeyType::Ed25519).unwrap();
+        assert_eq!(line, "[10.0.0.1]:2222 ssh-ed25519 AAEC");
+    }
+
+    #[test]
+    fn test_known_host_line_unknown_type_is_rejected() {
+        assert!(known_host_line("h", 22, b"abc", HostKeyType::Unknown).is_none());
     }
 }

--- a/crates/makiatto-cli/src/ssh.rs
+++ b/crates/makiatto-cli/src/ssh.rs
@@ -1,10 +1,11 @@
 use std::io::{Read, Write};
 use std::net::TcpStream;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use miette::{Result, miette};
-use ssh2::Session;
+use ssh2::{CheckResult, HostKeyType, KnownHostFileKind, Session};
 
 use crate::ui;
 
@@ -24,8 +25,9 @@ impl SshSession {
     /// # Errors
     /// Returns an error if connection fails or authentication fails
     pub fn new(ssh_target: &str, port: Option<u16>, key_path: Option<&PathBuf>) -> Result<Self> {
-        let port = port.unwrap_or(22);
-        let (user, host) = parse_ssh_target(ssh_target)?;
+        let (user, host, parsed_port) = parse_ssh_target(ssh_target)?;
+        // explicit --port wins, otherwise use a port embedded in the target, else 22
+        let port = port.or(parsed_port).unwrap_or(22);
 
         let tcp = TcpStream::connect((host.as_str(), port))
             .map_err(|e| miette!("Failed to connect to {host}:{port}: {e}"))?;
@@ -37,6 +39,11 @@ impl SshSession {
         session
             .handshake()
             .map_err(|e| miette!("SSH handshake failed: {e}"))?;
+
+        // verify the server's host key against ~/.ssh/known_hosts BEFORE
+        // authenticating, so we never hand the sudo password / WG private key to
+        // a machine-in-the-middle
+        verify_host_key(&session, &host, port)?;
 
         if let Some(key_path) = key_path {
             if session
@@ -89,11 +96,11 @@ impl SshSession {
 
         ssh.password = ssh.test_sudo()?;
 
-        if cfg!(debug_assertions) {
-            ssh.is_container = ssh
-                .execute_command_raw("[ -f /run/.containerenv ] || [ -f /.dockerenv ]", None)
-                .is_ok();
-        }
+        // detect container environments in all build profiles, not just debug —
+        // provisioning needs this to choose the background/no-wireguard path
+        ssh.is_container = ssh
+            .execute_command_raw("[ -f /run/.containerenv ] || [ -f /.dockerenv ]", None)
+            .is_ok();
 
         Ok(ssh)
     }
@@ -121,12 +128,15 @@ impl SshSession {
     /// # Errors
     /// Returns an error if command execution fails
     pub fn exec_stream(&self, command: &str) -> Result<i32> {
-        let command = if let Some(password) = &self.password
-            && command.starts_with("sudo ")
+        // Feed the sudo password over the (encrypted) channel stdin via `sudo -S`
+        // rather than `echo '{pw}' |`, which would leak it into the remote
+        // process list. `-p ''` suppresses the prompt text.
+        let (command, sudo_password) = if let Some(password) = &self.password
+            && let Some(rest) = command.strip_prefix("sudo ")
         {
-            format!("echo '{password}' | sudo -S {command}")
+            (format!("sudo -S -p '' {rest}"), Some(password.clone()))
         } else {
-            command.to_string()
+            (command.to_string(), None)
         };
 
         let mut channel = self
@@ -142,12 +152,21 @@ impl SshSession {
             .exec(&command)
             .map_err(|e| miette!("Failed to execute command: {e}"))?;
 
-        // Set channel to non-blocking so we can interleave reads and writes
-        self.session.set_blocking(false);
+        if let Some(password) = sudo_password {
+            channel
+                .write_all(format!("{password}\n").as_bytes())
+                .map_err(|e| miette!("Failed to send sudo password: {e}"))?;
+            channel.flush().ok();
+        }
 
-        // Put local terminal into raw mode so keypresses are forwarded immediately
+        // Put local terminal into raw mode so keypresses are forwarded immediately.
+        // Do this BEFORE switching the channel to non-blocking, so that if raw
+        // mode fails we never leave the session stuck in non-blocking mode.
         let _raw_guard = RawModeGuard::enter()
             .map_err(|e| miette!("Failed to enable raw terminal mode: {e}"))?;
+
+        // Set channel to non-blocking so we can interleave reads and writes
+        self.session.set_blocking(false);
 
         let mut buf = [0u8; 4096];
         let mut stdin_buf = [0u8; 256];
@@ -311,6 +330,15 @@ impl SshSession {
     }
 
     fn execute_command_raw(&self, command: &str, timeout: Option<Duration>) -> Result<String> {
+        self.execute_command_raw_with_stdin(command, None, timeout)
+    }
+
+    fn execute_command_raw_with_stdin(
+        &self,
+        command: &str,
+        stdin: Option<&str>,
+        timeout: Option<Duration>,
+    ) -> Result<String> {
         let session = &self.session;
 
         if let Some(timeout) = timeout {
@@ -326,6 +354,15 @@ impl SshSession {
         channel
             .exec(command)
             .map_err(|e| miette!("Failed to execute command '{command}': {e}"))?;
+
+        if let Some(data) = stdin {
+            channel
+                .write_all(data.as_bytes())
+                .map_err(|e| miette!("Failed to write to command stdin: {e}"))?;
+            channel
+                .send_eof()
+                .map_err(|e| miette!("Failed to send EOF: {e}"))?;
+        }
 
         let mut output = String::new();
         channel
@@ -372,35 +409,144 @@ impl SshSession {
         password: &str,
         timeout: Option<Duration>,
     ) -> Result<String> {
-        let sudo_command = format!("echo '{password}' | sudo -S {command}");
-        self.execute_command_raw(&sudo_command, timeout)
+        // strip the caller's leading `sudo ` so we don't end up with `sudo sudo`,
+        // then provide our own `sudo -S` and feed the password over the encrypted
+        // channel stdin (never via the remote process arguments)
+        let inner = command.strip_prefix("sudo ").unwrap_or(command);
+        let sudo_command = format!("sudo -S -p '' {inner}");
+        self.execute_command_raw_with_stdin(&sudo_command, Some(&format!("{password}\n")), timeout)
     }
 }
 
-pub(crate) fn parse_ssh_target(target: &str) -> Result<(String, String)> {
-    let parts: Vec<&str> = target.split('@').collect();
-    if parts.len() != 2 {
-        return Err(miette!(
-            "Invalid SSH target format. Expected user@host:port"
-        ));
-    }
-
-    let user = parts[0].to_string();
+pub(crate) fn parse_ssh_target(target: &str) -> Result<(String, String, Option<u16>)> {
+    let (user, host_port) = target
+        .split_once('@')
+        .ok_or_else(|| miette!("Invalid SSH target format. Expected user@host[:port]"))?;
 
     if user.is_empty() {
         return Err(miette!("User cannot be empty"));
     }
 
-    let host_port = parts[1];
-
-    let host_parts: Vec<&str> = host_port.split(':').collect();
-    let host = host_parts[0].to_string();
+    let (host, port) = if let Some(rest) = host_port.strip_prefix('[') {
+        // bracketed IPv6 literal: [::1] or [::1]:2222
+        let (addr, after) = rest
+            .split_once(']')
+            .ok_or_else(|| miette!("Invalid IPv6 SSH target: missing ']'"))?;
+        let port = match after.strip_prefix(':') {
+            Some(p) => Some(p.parse::<u16>().map_err(|_| miette!("Invalid port: {p}"))?),
+            None if after.is_empty() => None,
+            None => return Err(miette!("Unexpected characters after IPv6 address: {after:?}")),
+        };
+        (addr.to_string(), port)
+    } else if let Some((h, p)) = host_port.rsplit_once(':')
+        && !h.contains(':')
+    {
+        // exactly one colon: host:port (a bare IPv6 has multiple colons and is
+        // handled by the else branch)
+        (
+            h.to_string(),
+            Some(p.parse::<u16>().map_err(|_| miette!("Invalid port: {p}"))?),
+        )
+    } else {
+        // hostname / IPv4 with no port, or a bare IPv6 literal
+        (host_port.to_string(), None)
+    };
 
     if host.is_empty() {
         return Err(miette!("Host cannot be empty"));
     }
 
-    Ok((user, host))
+    Ok((user.to_string(), host, port))
+}
+
+/// Verify the server's host key against `~/.ssh/known_hosts`, trusting it on
+/// first use (TOFU). A mismatch is treated as a potential machine-in-the-middle
+/// and aborts the connection before any credentials are sent.
+fn verify_host_key(session: &Session, host: &str, port: u16) -> Result<()> {
+    let Some(home) = dirs::home_dir() else {
+        return Err(miette!(
+            "Cannot determine home directory for host key verification"
+        ));
+    };
+    let kh_path = home.join(".ssh").join("known_hosts");
+
+    let mut known_hosts = session
+        .known_hosts()
+        .map_err(|e| miette!("Failed to initialise known_hosts: {e}"))?;
+
+    if kh_path.exists() {
+        known_hosts
+            .read_file(&kh_path, KnownHostFileKind::OpenSSH)
+            .map_err(|e| miette!("Failed to read {}: {e}", kh_path.display()))?;
+    }
+
+    let (key, key_type) = session
+        .host_key()
+        .ok_or_else(|| miette!("Server did not present a host key"))?;
+
+    match known_hosts.check_port(host, port, key) {
+        CheckResult::Match => Ok(()),
+        CheckResult::Mismatch => Err(miette!(
+            "SSH host key mismatch for {host}:{port} — possible machine-in-the-middle. \
+             If the host key legitimately changed, remove the stale entry from {}.",
+            kh_path.display()
+        )),
+        CheckResult::Failure => Err(miette!("Host key verification failed for {host}:{port}")),
+        CheckResult::NotFound => {
+            append_known_host(&kh_path, host, port, key, key_type)?;
+            ui::info(&format!(
+                "Trusting new host key for {host}:{port} (added to {})",
+                kh_path.display()
+            ));
+            Ok(())
+        }
+    }
+}
+
+/// Append a host key to `known_hosts` in OpenSSH format (used for trust-on-first-use).
+fn append_known_host(
+    path: &Path,
+    host: &str,
+    port: u16,
+    key: &[u8],
+    key_type: HostKeyType,
+) -> Result<()> {
+    let key_type_str = match key_type {
+        HostKeyType::Rsa => "ssh-rsa",
+        HostKeyType::Dss => "ssh-dss",
+        HostKeyType::Ecdsa256 => "ecdsa-sha2-nistp256",
+        HostKeyType::Ecdsa384 => "ecdsa-sha2-nistp384",
+        HostKeyType::Ecdsa521 => "ecdsa-sha2-nistp521",
+        HostKeyType::Ed25519 => "ssh-ed25519",
+        HostKeyType::Unknown => {
+            return Err(miette!("Unknown host key type; refusing to record it"));
+        }
+    };
+
+    // OpenSSH represents non-default ports as [host]:port
+    let host_field = if port == 22 {
+        host.to_string()
+    } else {
+        format!("[{host}]:{port}")
+    };
+
+    let line = format!("{host_field} {key_type_str} {}\n", STANDARD.encode(key));
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| miette!("Failed to create {}: {e}", parent.display()))?;
+    }
+
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| miette!("Failed to open {}: {e}", path.display()))?;
+
+    file.write_all(line.as_bytes())
+        .map_err(|e| miette!("Failed to write to {}: {e}", path.display()))?;
+
+    Ok(())
 }
 
 /// RAII guard that puts the terminal into raw mode and restores it on drop.
@@ -462,7 +608,38 @@ mod tests {
     #[test]
     fn test_parse_ssh_target_without_port() {
         let result = parse_ssh_target("root@192.168.1.1").unwrap();
-        assert_eq!(result, ("root".to_string(), "192.168.1.1".to_string()));
+        assert_eq!(
+            result,
+            ("root".to_string(), "192.168.1.1".to_string(), None)
+        );
+    }
+
+    #[test]
+    fn test_parse_ssh_target_with_port() {
+        let result = parse_ssh_target("root@192.168.1.1:2222").unwrap();
+        assert_eq!(
+            result,
+            ("root".to_string(), "192.168.1.1".to_string(), Some(2222))
+        );
+    }
+
+    #[test]
+    fn test_parse_ssh_target_ipv6() {
+        let result = parse_ssh_target("root@[2001:db8::1]:2222").unwrap();
+        assert_eq!(
+            result,
+            ("root".to_string(), "2001:db8::1".to_string(), Some(2222))
+        );
+
+        let result = parse_ssh_target("root@[::1]").unwrap();
+        assert_eq!(result, ("root".to_string(), "::1".to_string(), None));
+
+        // bare IPv6 with no brackets and no port
+        let result = parse_ssh_target("root@2001:db8::1").unwrap();
+        assert_eq!(
+            result,
+            ("root".to_string(), "2001:db8::1".to_string(), None)
+        );
     }
 
     #[test]
@@ -470,5 +647,6 @@ mod tests {
         assert!(parse_ssh_target("invalid").is_err());
         assert!(parse_ssh_target("@host").is_err());
         assert!(parse_ssh_target("user@").is_err());
+        assert!(parse_ssh_target("user@host:notaport").is_err());
     }
 }

--- a/crates/makiatto-cli/src/sync.rs
+++ b/crates/makiatto-cli/src/sync.rs
@@ -704,3 +704,47 @@ fn sync_domain_transforms(ssh: &SshSession, domain: &Domain) -> Result<()> {
     corrosion::execute_transactions(ssh, &sqls)?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use super::resolve_env;
+
+    #[test]
+    fn resolve_env_merges_file_and_inline_with_inline_precedence() {
+        let dir = std::env::temp_dir().join(format!("maki-env-{}", uuid::Uuid::now_v7()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let env_file = dir.join(".env");
+        std::fs::write(
+            &env_file,
+            "A=from_file\nB=from_file\n# a comment\n\nC=\"quoted\"\n",
+        )
+        .unwrap();
+
+        let mut inline: HashMap<Arc<str>, Arc<str>> = HashMap::new();
+        inline.insert(Arc::from("B"), Arc::from("from_inline")); // overrides file
+        inline.insert(Arc::from("D"), Arc::from("inline_only"));
+
+        let json = resolve_env(Some(&env_file), &inline).unwrap();
+        let map: HashMap<String, String> = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(map.get("A").map(String::as_str), Some("from_file"));
+        assert_eq!(map.get("B").map(String::as_str), Some("from_inline"));
+        assert_eq!(map.get("C").map(String::as_str), Some("quoted")); // quotes stripped
+        assert_eq!(map.get("D").map(String::as_str), Some("inline_only"));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn resolve_env_without_file_uses_inline_only() {
+        let mut inline: HashMap<Arc<str>, Arc<str>> = HashMap::new();
+        inline.insert(Arc::from("X"), Arc::from("1"));
+        let json = resolve_env(None, &inline).unwrap();
+        let map: HashMap<String, String> = serde_json::from_str(&json).unwrap();
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get("X").map(String::as_str), Some("1"));
+    }
+}

--- a/crates/makiatto-cli/src/sync.rs
+++ b/crates/makiatto-cli/src/sync.rs
@@ -1,12 +1,19 @@
-use std::{collections::HashSet, path::PathBuf, time::SystemTime};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    sync::Arc,
+    time::SystemTime,
+};
 
 use argh::FromArgs;
 use miette::{Result, miette};
+use serde_json::json;
 use uuid::Uuid;
 
 use crate::{
     config::{Config, DnsRecord, Domain, Machine, Profile},
     machine::corrosion,
+    machine::corrosion::Statement,
     ssh::SshSession,
     ui,
 };
@@ -145,6 +152,13 @@ fn sync_domain_files(
         return Err(miette!(format!("Failed to pause file watcher: {e}")));
     }
 
+    // ensure the watcher is resumed no matter how we leave this function — an
+    // early error during rsync/chown/scan must not leave it paused forever
+    let _resume_guard = WatcherResumeGuard {
+        ssh,
+        wg_address: &machine.wg_address,
+    };
+
     let spinner = ui::spinner("Running rsync...");
 
     let source = domain.path.to_string_lossy();
@@ -163,10 +177,14 @@ fn sync_domain_files(
         )
     };
 
+    // single-quote-escape the password so a quote in it can't break out of the
+    // remote `echo '...'`. The password is still handed to the remote sudo via
+    // rsync's --rsync-path, which is inherent to running rsync under sudo.
     let rsync_path = if let Some(password) = &ssh.password {
-        &format!("echo '{password}' | sudo -S rsync")
+        let escaped = password.replace('\'', r"'\''");
+        format!("echo '{escaped}' | sudo -S rsync")
     } else {
-        "sudo rsync"
+        "sudo rsync".to_string()
     };
 
     let mut rsync_cmd = std::process::Command::new("rsync");
@@ -177,7 +195,7 @@ fn sync_domain_files(
         .arg("-e")
         .arg(&ssh_args)
         .arg("--rsync-path")
-        .arg(rsync_path)
+        .arg(&rsync_path)
         .arg(format!("{}/", source.trim_end_matches('/')))
         .arg(&target);
 
@@ -202,29 +220,41 @@ fn sync_domain_files(
         machine.wg_address, domain.name
     ))?;
 
-    if let Err(e) = ssh.exec(&format!(
-        "curl -s -X POST http://{}:8282/watcher/resume",
-        machine.wg_address
-    )) {
-        return Err(miette!(format!("Failed to resume file watcher: {e}")));
-    }
-
+    // the watcher is resumed by `_resume_guard` when this function returns
     Ok(())
+}
+
+/// Resumes the remote file watcher on drop, so a paused watcher is never left
+/// behind if a sync step fails partway through.
+struct WatcherResumeGuard<'a> {
+    ssh: &'a SshSession,
+    wg_address: &'a str,
+}
+
+impl Drop for WatcherResumeGuard<'_> {
+    fn drop(&mut self) {
+        if let Err(e) = self.ssh.exec(&format!(
+            "curl -s -X POST http://{}:8282/watcher/resume",
+            self.wg_address
+        )) {
+            ui::warn(&format!("Failed to resume file watcher: {e}"));
+        }
+    }
 }
 
 fn sync_domain_records(ssh: &SshSession, domain: &Domain, machines: &[Machine]) -> Result<()> {
     ui::status("Updating DNS records...");
 
-    let domain_sql = format!(
-        "INSERT OR IGNORE INTO domains (name) VALUES ('{}')",
-        domain.name
+    let domain_sql = Statement::with_params(
+        "INSERT OR IGNORE INTO domains (name) VALUES (?)",
+        vec![json!(domain.name.as_ref())],
     );
     corrosion::execute_transactions(ssh, &[domain_sql])?;
 
     for alias in domain.aliases.iter() {
-        let alias_sql = format!(
-            "INSERT OR REPLACE INTO domain_aliases (alias, target) VALUES ('{}', '{}')",
-            alias, domain.name
+        let alias_sql = Statement::with_params(
+            "INSERT OR REPLACE INTO domain_aliases (alias, target) VALUES (?, ?)",
+            vec![json!(alias.as_ref()), json!(domain.name.as_ref())],
         );
         corrosion::execute_transactions(ssh, &[alias_sql])?;
     }
@@ -478,9 +508,9 @@ fn apply_dns_diff(
             "Removing DNS record: {} {} -> {}",
             key.name, key.record_type, data.value
         ));
-        let sql = format!(
-            "DELETE FROM dns_records WHERE domain = '{}' AND name = '{}' AND record_type = '{}'",
-            domain, key.name, key.record_type
+        let sql = Statement::with_params(
+            "DELETE FROM dns_records WHERE domain = ? AND name = ? AND record_type = ?",
+            vec![json!(domain), json!(key.name), json!(key.record_type)],
         );
         sqls.push(sql);
     }
@@ -491,17 +521,19 @@ fn apply_dns_diff(
             key.name, key.record_type, data.value
         ));
         let id = Uuid::now_v7().to_string();
-        let sql = format!(
+        let sql = Statement::with_params(
             "INSERT INTO dns_records (id, domain, name, record_type, value, ttl, priority, geo_enabled) \
-             VALUES ('{}', '{}', '{}', '{}', '{}', {}, {}, {})",
-            id,
-            domain,
-            key.name,
-            key.record_type,
-            data.value,
-            data.ttl,
-            data.priority,
-            i32::from(data.geo_enabled)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            vec![
+                json!(id),
+                json!(domain),
+                json!(key.name),
+                json!(key.record_type),
+                json!(data.value),
+                json!(data.ttl),
+                json!(data.priority),
+                json!(i32::from(data.geo_enabled)),
+            ],
         );
         sqls.push(sql);
     }
@@ -523,6 +555,35 @@ fn apply_dns_diff(
     Ok(())
 }
 
+/// Merge an optional `env_file` (KEY=VALUE lines) with the inline `env` map and
+/// serialise the result to a JSON object string. Inline `env` entries take
+/// precedence over file entries.
+fn resolve_env(env_file: Option<&PathBuf>, env: &HashMap<Arc<str>, Arc<str>>) -> Result<String> {
+    let mut merged: HashMap<String, String> = HashMap::new();
+
+    if let Some(path) = env_file {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| miette!("Failed to read env_file '{}': {e}", path.display()))?;
+
+        for line in content.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            if let Some((key, value)) = line.split_once('=') {
+                let value = value.trim().trim_matches(['"', '\'']);
+                merged.insert(key.trim().to_string(), value.to_string());
+            }
+        }
+    }
+
+    for (key, value) in env {
+        merged.insert(key.to_string(), value.to_string());
+    }
+
+    serde_json::to_string(&merged).map_err(|e| miette!("Failed to serialise env: {e}"))
+}
+
 fn sync_domain_functions(ssh: &SshSession, domain: &Domain) -> Result<()> {
     if domain.functions.is_empty() {
         return Ok(());
@@ -530,9 +591,9 @@ fn sync_domain_functions(ssh: &SshSession, domain: &Domain) -> Result<()> {
 
     ui::status("Syncing WASM functions...");
 
-    let delete_sql = format!(
-        "DELETE FROM domain_functions WHERE domain = '{}'",
-        domain.name
+    let delete_sql = Statement::with_params(
+        "DELETE FROM domain_functions WHERE domain = ?",
+        vec![json!(domain.name.as_ref())],
     );
     corrosion::execute_transactions(ssh, &[delete_sql])?;
 
@@ -555,36 +616,28 @@ fn sync_domain_functions(ssh: &SshSession, domain: &Domain) -> Result<()> {
             "null".to_string()
         };
 
-        let env_json = serde_json::to_string(&function.env).unwrap_or_else(|_| "{}".to_string());
-
-        let timeout_ms = function
-            .timeout_ms
-            .map_or("NULL".to_string(), |t| t.to_string());
-        let max_memory_mb = function
-            .max_memory_mb
-            .map_or("NULL".to_string(), |m| m.to_string());
+        let env_json = resolve_env(function.env_file.as_ref(), &function.env)?;
 
         let updated_at = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_secs();
 
-        let sql = format!(
+        let sql = Statement::with_params(
             "INSERT INTO domain_functions (\
                 id, domain, path, methods, env, \
                 timeout_ms, max_memory_mb, updated_at\
-            ) VALUES (\
-                '{}', '{}', '{}', '{}', '{}', \
-                {}, {}, {}\
-            )",
-            id,
-            domain.name,
-            path_str,
-            methods_json,
-            env_json,
-            timeout_ms,
-            max_memory_mb,
-            updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            vec![
+                json!(id),
+                json!(domain.name.as_ref()),
+                json!(path_str),
+                json!(methods_json),
+                json!(env_json),
+                function.timeout_ms.map_or(json!(null), |t| json!(t)),
+                function.max_memory_mb.map_or(json!(null), |m| json!(m)),
+                json!(updated_at),
+            ],
         );
         sqls.push(sql);
 
@@ -603,9 +656,9 @@ fn sync_domain_transforms(ssh: &SshSession, domain: &Domain) -> Result<()> {
     ui::status("Syncing WASM transforms...");
 
     // Delete existing transforms for this domain
-    let delete_sql = format!(
-        "DELETE FROM domain_transforms WHERE domain = '{}'",
-        domain.name
+    let delete_sql = Statement::with_params(
+        "DELETE FROM domain_transforms WHERE domain = ?",
+        vec![json!(domain.name.as_ref())],
     );
     corrosion::execute_transactions(ssh, &[delete_sql])?;
 
@@ -614,43 +667,31 @@ fn sync_domain_transforms(ssh: &SshSession, domain: &Domain) -> Result<()> {
         let path_str = transform.path.display().to_string();
         let id = format!("{}:{}:{}", domain.name, path_str, idx);
 
-        let env_json = serde_json::to_string(&transform.env).unwrap_or_else(|_| "{}".to_string());
-
-        let timeout_ms = transform
-            .timeout_ms
-            .map_or("NULL".to_string(), |t| t.to_string());
-        let max_memory_mb = transform
-            .max_memory_mb
-            .map_or("NULL".to_string(), |m| m.to_string());
-        let max_file_size_kb = transform
-            .max_file_size_kb
-            .map_or("NULL".to_string(), |s| s.to_string());
+        let env_json = resolve_env(transform.env_file.as_ref(), &transform.env)?;
 
         let updated_at = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_secs();
 
-        let sql = format!(
+        let sql = Statement::with_params(
             "INSERT INTO domain_transforms (\
                 id, domain, path, files_pattern, env, \
                 timeout_ms, max_memory_mb, max_file_size_kb, \
                 execution_order, updated_at\
-            ) VALUES (\
-                '{}', '{}', '{}', '{}', '{}', \
-                {}, {}, {}, \
-                {}, {}\
-            )",
-            id,
-            domain.name,
-            path_str,
-            transform.files,
-            env_json,
-            timeout_ms,
-            max_memory_mb,
-            max_file_size_kb,
-            idx,
-            updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            vec![
+                json!(id),
+                json!(domain.name.as_ref()),
+                json!(path_str),
+                json!(transform.files.as_ref()),
+                json!(env_json),
+                transform.timeout_ms.map_or(json!(null), |t| json!(t)),
+                transform.max_memory_mb.map_or(json!(null), |m| json!(m)),
+                transform.max_file_size_kb.map_or(json!(null), |s| json!(s)),
+                json!(idx),
+                json!(updated_at),
+            ],
         );
         sqls.push(sql);
 

--- a/crates/makiatto/build.rs
+++ b/crates/makiatto/build.rs
@@ -21,7 +21,12 @@ fn main() {
     println!("cargo:rustc-env=DATABASE_URL=sqlite:{}", db_path.display());
     let _ = std::fs::remove_file(&db_path);
 
+    println!("cargo:rerun-if-changed=build.rs");
+
     let schemas_dir = Path::new("schemas");
+    // rerun if schema files are added or removed
+    println!("cargo:rerun-if-changed={}", schemas_dir.display());
+
     let mut schema_files = std::fs::read_dir(schemas_dir)
         .expect("Failed to read schemas directory")
         .collect::<Result<Vec<_>, _>>()
@@ -31,11 +36,13 @@ fn main() {
 
     let mut combined_sql = String::new();
     for entry in schema_files {
-        if let Some(ext) = entry.path().extension()
+        let path = entry.path();
+        if let Some(ext) = path.extension()
             && ext == "sql"
         {
-            let content =
-                std::fs::read_to_string(entry.path()).expect("Failed to read schema file");
+            // rerun if any individual schema file's contents change
+            println!("cargo:rerun-if-changed={}", path.display());
+            let content = std::fs::read_to_string(&path).expect("Failed to read schema file");
             combined_sql.push_str(&content);
             combined_sql.push('\n');
         }

--- a/crates/makiatto/src/cache.rs
+++ b/crates/makiatto/src/cache.rs
@@ -19,9 +19,6 @@ struct CacheData {
     subscriptions: HashMap<String, SubscriptionState>,
 
     #[serde(default)]
-    cache: HashMap<String, serde_json::Value>,
-
-    #[serde(default)]
     version: u32,
 }
 
@@ -87,21 +84,21 @@ impl CacheStore {
         let content = serde_json::to_string_pretty(&*data)
             .map_err(|e| miette::miette!("Failed to serialize cache data: {e}"))?;
 
-        // Write to temporary file first for atomicity
-        let temp_path = format!("{}.tmp", self.path);
+        // Write to a uniquely-named temp file first for atomicity. A unique name
+        // avoids two concurrent persists clobbering each other's temp file.
+        let temp_path = format!("{}.tmp.{}", self.path, uuid::Uuid::new_v4());
         tokio::fs::write(&temp_path, content)
             .await
             .map_err(|e| miette::miette!("Failed to write cache file to {temp_path}: {e}"))?;
 
         // Rename to final location (atomic on most filesystems)
-        tokio::fs::rename(&temp_path, &self.path)
-            .await
-            .map_err(|e| {
-                miette::miette!(
-                    "Failed to rename cache file from {temp_path} to {}: {e}",
-                    self.path
-                )
-            })?;
+        if let Err(e) = tokio::fs::rename(&temp_path, &self.path).await {
+            let _ = tokio::fs::remove_file(&temp_path).await;
+            return Err(miette::miette!(
+                "Failed to rename cache file from {temp_path} to {}: {e}",
+                self.path
+            ));
+        }
 
         debug!("Persisted cache to {}", self.path);
         Ok(())

--- a/crates/makiatto/src/config.rs
+++ b/crates/makiatto/src/config.rs
@@ -117,6 +117,13 @@ pub struct WebConfig {
     /// Request timeout in seconds (default: 60)
     #[serde(default = "default_request_timeout_secs")]
     pub request_timeout_secs: u64,
+
+    /// Trust `Forwarded` / `X-Forwarded-Host` headers when resolving the request
+    /// host. Only enable this behind a trusted reverse proxy — on an
+    /// internet-facing edge these headers are client-spoofable and would let an
+    /// attacker choose which site is served (default: false).
+    #[serde(default = "default_false")]
+    pub trust_forwarded_host: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -140,6 +147,11 @@ pub struct ImageConfig {
     /// Allowed output formats
     #[serde(default = "default_allowed_formats")]
     pub allowed_formats: Vec<String>,
+
+    /// Maximum source image size in bytes that will be decoded (guards against
+    /// decode-bomb / memory-exhaustion via a huge source file)
+    #[serde(default = "default_max_source_bytes")]
+    pub max_source_bytes: u64,
 }
 
 impl Default for ImageConfig {
@@ -150,8 +162,13 @@ impl Default for ImageConfig {
             max_width: default_max_dimension(),
             max_height: default_max_dimension(),
             allowed_formats: default_allowed_formats(),
+            max_source_bytes: default_max_source_bytes(),
         }
     }
+}
+
+fn default_max_source_bytes() -> u64 {
+    50 * 1024 * 1024 // 50 MiB
 }
 
 fn default_max_concurrent_requests() -> usize {

--- a/crates/makiatto/src/corrosion.rs
+++ b/crates/makiatto/src/corrosion.rs
@@ -3,6 +3,8 @@ use std::sync::{Arc, OnceLock};
 use camino::Utf8Path;
 use miette::Result;
 use schema::{DnsRecord, Peer};
+use serde::Serialize;
+use serde_json::Value;
 use sqlx::SqlitePool;
 use tracing::{error, info};
 use tripwire;
@@ -64,7 +66,7 @@ pub async fn get_pool() -> Result<&'static SqlitePool> {
     ))
 }
 
-/// Get all peers from the database, excluding the current machine
+/// Get all peers from the database (including the current machine).
 ///
 /// # Errors
 /// Returns an error if the database query fails
@@ -173,16 +175,52 @@ pub async fn get_domains() -> Result<Vec<String>> {
     Ok(domains)
 }
 
+/// A SQL statement for the Corrosion `/v1/transactions` API.
+///
+/// Serialises to Corrosion's wire format: a bare string for [`Statement::Simple`],
+/// or `[sql, [params]]` for [`Statement::WithParams`]. Always prefer the
+/// parameterised form for any value that is not a compile-time constant — the
+/// statement is gossiped to and executed on every node in the cluster, so an
+/// unescaped quote is a cluster-wide SQL injection.
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum Statement {
+    /// A literal SQL statement with no bound parameters.
+    Simple(String),
+    /// A parameterised statement: `(sql, params)` bound positionally to `?`.
+    WithParams(String, Vec<Value>),
+}
+
+impl Statement {
+    /// Build a parameterised statement.
+    #[must_use]
+    pub fn with_params(sql: impl Into<String>, params: Vec<Value>) -> Self {
+        Self::WithParams(sql.into(), params)
+    }
+}
+
+impl From<String> for Statement {
+    fn from(sql: String) -> Self {
+        Self::Simple(sql)
+    }
+}
+
+impl From<&str> for Statement {
+    fn from(sql: &str) -> Self {
+        Self::Simple(sql.to_string())
+    }
+}
+
 /// Execute SQL transactions via Corrosion API
 ///
 /// # Errors
 /// Returns an error if the HTTP request fails or the API returns an error
-pub async fn execute_transactions(sqls: &[String]) -> Result<()> {
-    if sqls.is_empty() {
+pub async fn execute_transactions(statements: &[Statement]) -> Result<()> {
+    if statements.is_empty() {
         return Ok(());
     }
 
-    let json_payload = serde_json::to_string(sqls)
+    let json_payload = serde_json::to_string(statements)
         .map_err(|e| miette::miette!("Failed to serialise SQL statements: {e}"))?;
 
     let client = reqwest::Client::new();

--- a/crates/makiatto/src/corrosion.rs
+++ b/crates/makiatto/src/corrosion.rs
@@ -285,3 +285,44 @@ pub async fn run(config: Arc<Config>, tripwire: tripwire::Tripwire) -> Result<()
     info!("Corrosion agent stopped");
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::Statement;
+
+    #[test]
+    fn simple_statement_serialises_as_bare_string() {
+        let stmt = Statement::from("DELETE FROM files");
+        assert_eq!(
+            serde_json::to_string(&stmt).unwrap(),
+            r#""DELETE FROM files""#
+        );
+    }
+
+    #[test]
+    fn parameterised_statement_serialises_as_sql_and_params() {
+        let stmt = Statement::with_params(
+            "DELETE FROM files WHERE domain = ? AND path = ?",
+            vec![json!("a'; DROP TABLE files;--"), json!("/index.html")],
+        );
+        // the dangerous value stays in the params array, never interpolated into SQL
+        assert_eq!(
+            serde_json::to_string(&stmt).unwrap(),
+            r#"["DELETE FROM files WHERE domain = ? AND path = ?",["a'; DROP TABLE files;--","/index.html"]]"#
+        );
+    }
+
+    #[test]
+    fn transaction_batch_serialises_as_array() {
+        let stmts = vec![
+            Statement::from("BEGIN"),
+            Statement::with_params("INSERT INTO t VALUES (?)", vec![json!(1)]),
+        ];
+        assert_eq!(
+            serde_json::to_string(&stmts).unwrap(),
+            r#"["BEGIN",["INSERT INTO t VALUES (?)",[1]]]"#
+        );
+    }
+}

--- a/crates/makiatto/src/corrosion/consensus.rs
+++ b/crates/makiatto/src/corrosion/consensus.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use miette::Result;
+use serde_json::json;
 use tokio::sync::RwLock;
 use tokio::time::{Duration, interval};
 use tracing::{debug, error, info, warn};
@@ -11,6 +12,15 @@ use crate::config::Config;
 use crate::corrosion::{self, schema::ClusterLeadership};
 
 const DIRECTOR_ROLE: &str = "director";
+
+/// Wait this long after writing a leadership claim before re-reading it, giving
+/// a competing peer's claim time to gossip in so we don't act on a stale local win.
+const CONVERGENCE_DELAY_MS: u64 = 500;
+
+/// Tolerated clock skew (seconds) when judging whether another node's lease has
+/// expired. We only treat a remote lease as expired once it is stale by more than
+/// this margin, to avoid two nodes both stealing leadership across clock drift.
+const CLOCK_SKEW_MARGIN_SECS: i64 = 5;
 
 #[derive(Debug, Clone)]
 pub struct DirectorElection {
@@ -99,8 +109,8 @@ impl DirectorElection {
                         Err(e) => error!("Failed to claim leadership: {e}"),
                     }
                 }
-            } else if leader.expires_at < current_time {
-                // leader expired, try to claim leadership
+            } else if leader.expires_at + CLOCK_SKEW_MARGIN_SECS < current_time {
+                // leader expired (beyond the clock-skew margin), try to claim leadership
                 info!(
                     "Current leader '{}' expired (expires_at: {}, current_time: {}), attempting to claim leadership",
                     leader.node_name, leader.expires_at, current_time
@@ -147,32 +157,39 @@ impl DirectorElection {
     ) -> Result<()> {
         let expires_at = current_time + lease_duration;
 
-        let sql = format!(
+        // The conflict guard also tie-breaks on node_name: when two nodes race to
+        // claim the same term, the row only updates if the incumbent's term/lease
+        // is stale OR our name sorts lower. This gives a deterministic winner once
+        // CR-SQLite gossip converges, rather than each node trusting its own
+        // optimistic local write.
+        let sql = corrosion::Statement::with_params(
             r"
             INSERT INTO cluster_leadership (role, node_name, term, last_heartbeat, expires_at)
-            VALUES ('{}', '{}', {}, {}, {})
+            VALUES (?, ?, ?, ?, ?)
             ON CONFLICT(role) DO UPDATE SET
-                node_name = '{}',
-                term = {},
-                last_heartbeat = {},
-                expires_at = {}
-            WHERE term < {} OR expires_at < {}
+                node_name = excluded.node_name,
+                term = excluded.term,
+                last_heartbeat = excluded.last_heartbeat,
+                expires_at = excluded.expires_at
+            WHERE cluster_leadership.term < excluded.term
+                OR cluster_leadership.expires_at < excluded.last_heartbeat
+                OR (cluster_leadership.term = excluded.term
+                    AND excluded.node_name < cluster_leadership.node_name)
             ",
-            DIRECTOR_ROLE,
-            self.node_name,
-            new_term,
-            current_time,
-            expires_at,
-            self.node_name,
-            new_term,
-            current_time,
-            expires_at,
-            new_term,
-            current_time,
+            vec![
+                json!(DIRECTOR_ROLE),
+                json!(self.node_name.as_ref()),
+                json!(new_term),
+                json!(current_time),
+                json!(expires_at),
+            ],
         );
 
         corrosion::execute_transactions(&[sql]).await?;
 
+        // Re-read after a short convergence delay so a peer's competing claim has
+        // a chance to gossip in before we act on a (possibly stale) local win.
+        tokio::time::sleep(Duration::from_millis(CONVERGENCE_DELAY_MS)).await;
         let leadership = self.get_current_leadership().await?;
 
         if let Some(leader) = leadership {
@@ -204,13 +221,19 @@ impl DirectorElection {
         let current_term = state.current_term;
         drop(state);
 
-        let sql = format!(
+        let sql = corrosion::Statement::with_params(
             r"
             UPDATE cluster_leadership
-            SET last_heartbeat = {}, expires_at = {}
-            WHERE role = '{}' AND node_name = '{}' AND term = {}
+            SET last_heartbeat = ?, expires_at = ?
+            WHERE role = ? AND node_name = ? AND term = ?
             ",
-            current_time, expires_at, DIRECTOR_ROLE, self.node_name, current_term
+            vec![
+                json!(current_time),
+                json!(expires_at),
+                json!(DIRECTOR_ROLE),
+                json!(self.node_name.as_ref()),
+                json!(current_term),
+            ],
         );
 
         match corrosion::execute_transactions(&[sql]).await {
@@ -274,12 +297,16 @@ impl DirectorElection {
         let current_term = state.current_term;
         drop(state);
 
-        let sql = format!(
+        let sql = corrosion::Statement::with_params(
             r"
             DELETE FROM cluster_leadership
-            WHERE role = '{}' AND node_name = '{}' AND term = {}
+            WHERE role = ? AND node_name = ? AND term = ?
             ",
-            DIRECTOR_ROLE, self.node_name, current_term
+            vec![
+                json!(DIRECTOR_ROLE),
+                json!(self.node_name.as_ref()),
+                json!(current_term),
+            ],
         );
 
         if corrosion::execute_transactions(&[sql]).await.is_ok() {

--- a/crates/makiatto/src/corrosion/health.rs
+++ b/crates/makiatto/src/corrosion/health.rs
@@ -258,19 +258,19 @@ impl HealthMonitor {
             .map_err(|e| miette::miette!("Failed to get current time: {e}"))?
             .as_secs() as i64;
 
-        let sql = format!(
+        let sql = corrosion::Statement::with_params(
             r"
             INSERT INTO unhealthy_nodes (node_name, marked_unhealthy_at, failure_reason)
-            VALUES ('{}', {}, '{}')
+            VALUES (?, ?, ?)
             ON CONFLICT(node_name) DO UPDATE SET
-                marked_unhealthy_at = {},
-                failure_reason = '{}'
+                marked_unhealthy_at = excluded.marked_unhealthy_at,
+                failure_reason = excluded.failure_reason
             ",
-            node_name.replace('\'', "''"),
-            current_time,
-            failure_reason.replace('\'', "''"),
-            current_time,
-            failure_reason.replace('\'', "''"),
+            vec![
+                serde_json::json!(node_name),
+                serde_json::json!(current_time),
+                serde_json::json!(failure_reason),
+            ],
         );
 
         corrosion::execute_transactions(&[sql]).await?;
@@ -285,12 +285,12 @@ impl HealthMonitor {
 
     /// Mark a node as healthy
     async fn mark_node_healthy(&self, node_name: &str) -> Result<()> {
-        let sql = format!(
+        let sql = corrosion::Statement::with_params(
             r"
             DELETE FROM unhealthy_nodes
-            WHERE node_name = '{}'
+            WHERE node_name = ?
             ",
-            node_name.replace('\'', "''"),
+            vec![serde_json::json!(node_name)],
         );
 
         corrosion::execute_transactions(&[sql]).await?;

--- a/crates/makiatto/src/corrosion/subscriptions.rs
+++ b/crates/makiatto/src/corrosion/subscriptions.rs
@@ -20,7 +20,11 @@ use crate::{
     wireguard::{WireguardManager, resolve_endpoint},
 };
 
-const MAX_BACKOFF_SECS: u64 = 86400; // 1 day
+const MAX_BACKOFF_SECS: u64 = 300; // 5 minutes
+
+/// If a subscription stayed up at least this long before ending, treat it as a
+/// healthy run and reset the reconnect backoff.
+const HEALTHY_RUN_SECS: u64 = 60;
 
 pub struct SubscriptionWatcher {
     config: Arc<Config>,
@@ -234,48 +238,32 @@ impl SubscriptionWatcher {
             }
         });
 
+        let watcher_handles = vec![
+            peers_handle,
+            dns_handle,
+            certificates_handle,
+            domains_handle,
+            domain_aliases_handle,
+            files_handle,
+            unhealthy_nodes_handle,
+            cache_persist_handle,
+        ];
+
         tokio::select! {
             () = &mut tripwire => {
                 info!("Subscription watcher shutting down");
+                // each task also holds the tripwire and exits on its own
             }
-            res = peers_handle => {
-                if let Err(e) = res {
-                    error!("Peers watcher task failed: {e}");
+            (res, idx, rest) = futures::future::select_all(watcher_handles) => {
+                // a subscription task ended unexpectedly. Don't silently detach
+                // the others (which would leave subscriptions partially working);
+                // abort them so the whole unit stops and the supervisor notices.
+                match res {
+                    Ok(()) => warn!("Subscription watcher task {idx} exited unexpectedly"),
+                    Err(e) => error!("Subscription watcher task {idx} failed: {e}"),
                 }
-            }
-            res = dns_handle => {
-                if let Err(e) = res {
-                    error!("DNS records watcher task failed: {e}");
-                }
-            }
-            res = certificates_handle => {
-                if let Err(e) = res {
-                    error!("Certificates watcher task failed: {e}");
-                }
-            }
-            res = domains_handle => {
-                if let Err(e) = res {
-                    error!("Domains watcher task failed: {e}");
-                }
-            }
-            res = domain_aliases_handle => {
-                if let Err(e) = res {
-                    error!("Domain aliases watcher task failed: {e}");
-                }
-            }
-            res = files_handle => {
-                if let Err(e) = res {
-                    error!("Files watcher task failed: {e}");
-                }
-            }
-            res = unhealthy_nodes_handle => {
-                if let Err(e) = res {
-                    error!("Unhealthy nodes watcher task failed: {e}");
-                }
-            }
-            res = cache_persist_handle => {
-                if let Err(e) = res {
-                    error!("Cache persistence task failed: {e}");
+                for handle in rest {
+                    handle.abort();
                 }
             }
         }
@@ -295,6 +283,8 @@ impl SubscriptionWatcher {
         let mut backoff_secs = 1u64;
 
         loop {
+            let run_start = std::time::Instant::now();
+
             tokio::select! {
                 () = &mut tripwire => {
                     info!("{table_name} watcher shutting down");
@@ -304,8 +294,14 @@ impl SubscriptionWatcher {
                     if let Err(e) = result {
                         warn!("{table_name} subscription failed: {e}, retrying in {backoff_secs} seconds");
                     } else {
-                        backoff_secs = 1;
                         warn!("{table_name} subscription ended, retrying...");
+                    }
+
+                    // a subscription that stayed up for a while was healthy, so
+                    // reset the backoff rather than letting transient drops ramp
+                    // it up indefinitely
+                    if run_start.elapsed() >= Duration::from_secs(HEALTHY_RUN_SECS) {
+                        backoff_secs = 1;
                     }
 
                     sleep(Duration::from_secs(backoff_secs)).await;

--- a/crates/makiatto/src/fs.rs
+++ b/crates/makiatto/src/fs.rs
@@ -44,6 +44,11 @@ pub async fn start(
     config: Arc<Config>,
     mut shutdown_rx: tokio::sync::mpsc::Receiver<()>,
 ) -> Result<()> {
+    // Note on the control endpoints (/watcher/pause|resume, /scan): they are
+    // unauthenticated, so the server must only be bound to the trusted WireGuard
+    // mesh address (the default below) and never to a public interface. Mesh
+    // peers are already fully trusted (they share the replicated, cluster-wide
+    // database), so these endpoints add no privilege beyond that trust boundary.
     let app = Router::new()
         .nest_service("/files", ServeDir::new(config.fs.storage_dir.as_std_path()))
         .route("/scan/{domain}", post(handle_domain_scan))

--- a/crates/makiatto/src/fs/reconcile.rs
+++ b/crates/makiatto/src/fs/reconcile.rs
@@ -431,10 +431,7 @@ pub mod domain {
 
                 let delete_sql = corrosion::Statement::with_params(
                     "DELETE FROM files WHERE domain = ? AND path = ?",
-                    vec![
-                        serde_json::json!(db_domain),
-                        serde_json::json!(db_path),
-                    ],
+                    vec![serde_json::json!(db_domain), serde_json::json!(db_path)],
                 );
                 delete_sqls.push(delete_sql);
                 deleted_count += 1;

--- a/crates/makiatto/src/fs/reconcile.rs
+++ b/crates/makiatto/src/fs/reconcile.rs
@@ -467,6 +467,10 @@ async fn scan_directory_recursive(dir: &std::path::Path) -> Result<Vec<std::path
     if let Ok(mut entries) = tokio::fs::read_dir(dir).await {
         while let Ok(Some(entry)) = entries.next_entry().await {
             let path = entry.path();
+            // skip the daemon's own staging temp files
+            if crate::fs::watcher::is_temp_file(&path) {
+                continue;
+            }
             if entry.file_type().await.is_ok_and(|t| t.is_file()) {
                 files.push(path);
             } else if entry.file_type().await.is_ok_and(|t| t.is_dir())

--- a/crates/makiatto/src/fs/reconcile.rs
+++ b/crates/makiatto/src/fs/reconcile.rs
@@ -35,7 +35,12 @@ use crate::{
 /// Returns an error if reconciliation fails
 pub async fn run_once(config: Arc<Config>) -> Result<()> {
     info!("Running startup filesystem reconciliation");
-    system::reconcile_all(&config).await?;
+    // Do not delete on-disk files during startup: a freshly started node's
+    // database may still be catching up via gossip, so disk can legitimately
+    // hold files that have no local row yet. Deleting them here would be data
+    // loss. Startup only fetches genuinely missing files; the periodic
+    // reconciliation handles orphan/content cleanup once replication settles.
+    system::reconcile_all(&config, false).await?;
     info!("Startup reconciliation completed");
     Ok(())
 }
@@ -63,7 +68,7 @@ pub async fn start(config: Arc<Config>, mut shutdown_rx: mpsc::Receiver<()>) -> 
             }
             _ = interval.tick() => {
                 info!("Starting filesystem reconciliation check");
-                if let Err(e) = system::reconcile_all(&config).await {
+                if let Err(e) = system::reconcile_all(&config, true).await {
                     error!("Filesystem reconciliation failed: {e}");
                 } else {
                     info!("Filesystem reconciliation completed successfully");
@@ -80,17 +85,27 @@ mod system {
     use super::*;
 
     /// Comprehensive system-wide reconciliation for all domains
-    pub async fn reconcile_all(config: &Config) -> Result<()> {
+    ///
+    /// When `allow_deletions` is false, only missing files are fetched and no
+    /// on-disk files or content are removed. This is used at startup, before
+    /// replication has necessarily settled, to avoid deleting valid data.
+    pub async fn reconcile_all(config: &Config, allow_deletions: bool) -> Result<()> {
         let mut issues_found = 0;
 
         // 1. check all DB records have corresponding files
         issues_found += reconcile_missing_files(config).await?;
 
-        // 2. check all domain files have DB records - remove those that don't
-        issues_found += reconcile_orphaned_files(config).await?;
+        if allow_deletions {
+            // 2. check all domain files have DB records - remove those that don't
+            issues_found += reconcile_orphaned_files(config).await?;
 
-        // 3. clean up unreferenced content files
-        issues_found += cleanup_orphaned_content(config).await?;
+            // 3. clean up unreferenced content files
+            issues_found += cleanup_orphaned_content(config).await?;
+        } else {
+            debug!(
+                "Skipping orphan and content cleanup (deletions disabled until replication settles)"
+            );
+        }
 
         if issues_found > 0 {
             warn!("Reconciliation found and fixed {issues_found} issues");
@@ -414,8 +429,12 @@ pub mod domain {
                     db_domain, db_path
                 );
 
-                let delete_sql = format!(
-                    "DELETE FROM files WHERE domain = '{db_domain}' AND path = '{db_path}'"
+                let delete_sql = corrosion::Statement::with_params(
+                    "DELETE FROM files WHERE domain = ? AND path = ?",
+                    vec![
+                        serde_json::json!(db_domain),
+                        serde_json::json!(db_path),
+                    ],
                 );
                 delete_sqls.push(delete_sql);
                 deleted_count += 1;

--- a/crates/makiatto/src/fs/watcher.rs
+++ b/crates/makiatto/src/fs/watcher.rs
@@ -1016,3 +1016,40 @@ async fn stream_download_and_verify(
     debug!("Successfully streamed and verified file {expected_hash}");
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io::Error;
+    use std::path::Path;
+
+    use super::{TEMP_FILE_PREFIX, is_cross_device, is_temp_file, should_fallback_to_copy};
+
+    #[test]
+    fn temp_files_are_recognised_and_ignored() {
+        assert!(is_temp_file(Path::new(&format!(
+            "/sites/localhost/api/{TEMP_FILE_PREFIX}abc-123"
+        ))));
+        // real content files must NOT be treated as temp files
+        assert!(!is_temp_file(Path::new("/sites/localhost/api/hello.wasm")));
+        assert!(!is_temp_file(Path::new("/sites/localhost/index.html")));
+        // a similar-but-not-matching name is not a temp file
+        assert!(!is_temp_file(Path::new("/sites/localhost/.makiatto-tmp")));
+    }
+
+    #[test]
+    fn cross_device_is_detected_from_exdev() {
+        // EXDEV (18) is the cross-filesystem error the copy fallback handles
+        assert!(is_cross_device(&Error::from_raw_os_error(18)));
+        assert!(!is_cross_device(&Error::from_raw_os_error(1))); // EPERM
+        assert!(!is_cross_device(&Error::from_raw_os_error(13))); // EACCES
+    }
+
+    #[test]
+    fn copy_fallback_covers_perm_and_xdev() {
+        assert!(should_fallback_to_copy(&Error::from_raw_os_error(1))); // EPERM
+        assert!(should_fallback_to_copy(&Error::from_raw_os_error(13))); // EACCES
+        assert!(should_fallback_to_copy(&Error::from_raw_os_error(18))); // EXDEV
+        // a generic IO error should not trigger the copy fallback
+        assert!(!should_fallback_to_copy(&Error::from_raw_os_error(2))); // ENOENT
+    }
+}

--- a/crates/makiatto/src/fs/watcher.rs
+++ b/crates/makiatto/src/fs/watcher.rs
@@ -4,6 +4,7 @@ use std::{path::PathBuf, sync::Arc, time::Duration};
 use blake3::Hasher;
 use futures_util::StreamExt;
 use miette::Result;
+use serde_json::json;
 use notify_debouncer_full::{
     DebounceEventResult, new_debouncer,
     notify::{EventKind, RecursiveMode, event::CreateKind},
@@ -94,18 +95,22 @@ async fn handle_debounced_events(
     let mut delete_paths = Vec::new();
 
     for event in events {
+        let Some(path) = event.paths.first() else {
+            continue;
+        };
+
         match event.kind {
             EventKind::Create(CreateKind::File) => {
-                debug!("File created: {}", event.paths[0].display());
-                file_paths.push(event.paths[0].clone());
+                debug!("File created: {}", path.display());
+                file_paths.push(path.clone());
             }
             EventKind::Modify(_) => {
-                debug!("File modified: {}", event.paths[0].display());
-                file_paths.push(event.paths[0].clone());
+                debug!("File modified: {}", path.display());
+                file_paths.push(path.clone());
             }
             EventKind::Remove(_) => {
-                debug!("File removed: {}", event.paths[0].display());
-                delete_paths.push(event.paths[0].clone());
+                debug!("File removed: {}", path.display());
+                delete_paths.push(path.clone());
             }
             _ => {}
         }
@@ -314,11 +319,11 @@ pub async fn process_file_change(
 /// # Errors
 /// Returns an error if database operations fail
 pub async fn update_file_records(records: &[File], config: &Config) -> Result<()> {
+    let pool = corrosion::get_pool().await?;
     let mut sqls = Vec::new();
     let mut existing_hashes = Vec::new();
 
     for record in records {
-        let pool = corrosion::get_pool().await?;
         let domain_str = record.domain.as_ref();
         let path_str = record.path.as_ref();
         let content_hash = record.content_hash.as_ref();
@@ -332,18 +337,20 @@ pub async fn update_file_records(records: &[File], config: &Config) -> Result<()
         .await
         .map_err(|e| miette::miette!("Failed to check existing file record: {e}"))?;
 
-        let sql = format!(
+        let sql = corrosion::Statement::with_params(
             "INSERT INTO files (domain, path, content_hash, size, modified_at)
-            VALUES ('{}', '{}', '{}', {}, {})
-            ON CONFLICT(domain, path) DO UPDATE SET content_hash='{}', size={}, modified_at={}",
-            record.domain,
-            record.path,
-            record.content_hash,
-            record.size,
-            record.modified_at,
-            record.content_hash,
-            record.size,
-            record.modified_at
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(domain, path) DO UPDATE SET content_hash = ?, size = ?, modified_at = ?",
+            vec![
+                json!(record.domain.as_ref()),
+                json!(record.path.as_ref()),
+                json!(record.content_hash.as_ref()),
+                json!(record.size),
+                json!(record.modified_at),
+                json!(record.content_hash.as_ref()),
+                json!(record.size),
+                json!(record.modified_at),
+            ],
         );
 
         sqls.push(sql);
@@ -383,10 +390,13 @@ async fn delete_file_records(records: &[(String, String)]) -> Result<()> {
         return Ok(());
     }
 
-    let sqls: Vec<String> = records
+    let sqls: Vec<corrosion::Statement> = records
         .iter()
         .map(|(domain, path)| {
-            format!("DELETE FROM files WHERE domain = '{domain}' AND path = '{path}'")
+            corrosion::Statement::with_params(
+                "DELETE FROM files WHERE domain = ? AND path = ?",
+                vec![json!(domain), json!(path)],
+            )
         })
         .collect();
 
@@ -445,8 +455,14 @@ async fn recreate_hardlinks_for_content(config: &Config, content_hash: &str) -> 
     }
 
     for (domain, path) in files {
-        let domain_dir = config.web.static_dir.as_std_path().join(&domain);
-        let file_path = domain_dir.join(path.trim_start_matches('/'));
+        let file_path =
+            match util::contained_path(config.web.static_dir.as_std_path(), &domain, &path) {
+                Ok(p) => p,
+                Err(e) => {
+                    warn!("Skipping unsafe file record {domain}{path}: {e}");
+                    continue;
+                }
+            };
 
         // Check if file exists and is properly hardlinked
         if file_path.exists() {
@@ -630,8 +646,7 @@ pub async fn recreate_domain_file(
     path: &str,
     content_hash: &str,
 ) -> Result<()> {
-    let domain_dir = config.web.static_dir.as_std_path().join(domain);
-    let file_path = domain_dir.join(path.trim_start_matches('/'));
+    let file_path = util::contained_path(config.web.static_dir.as_std_path(), domain, path)?;
     let content_path = config.fs.storage_dir.join(content_hash);
 
     if let Some(parent) = file_path.parent() {
@@ -674,10 +689,13 @@ async fn create_hardlink(source: &std::path::Path, target: &std::path::Path) -> 
             return Ok(());
         }
 
-        // file exists but isn't the right hardlink - use atomic rename
+        // file exists but isn't the right hardlink - use atomic rename.
+        // place the temp file in the *target's* directory so the final rename is
+        // always within one filesystem (avoids EXDEV when storage and the site
+        // directory live on different filesystems)
         let temp_filename = format!(".tmp.{}", uuid::Uuid::new_v4());
 
-        let temp_path = source
+        let temp_path = target
             .parent()
             .unwrap_or(std::path::Path::new("/tmp"))
             .join(temp_filename);
@@ -759,8 +777,7 @@ async fn create_hardlink(source: &std::path::Path, target: &std::path::Path) -> 
 /// # Errors
 /// Returns an error if the file cannot be deleted
 pub async fn delete_domain_file(config: &Config, domain: &str, path: &str) -> Result<()> {
-    let domain_dir = config.web.static_dir.as_std_path().join(domain);
-    let file_path = domain_dir.join(path.trim_start_matches('/'));
+    let file_path = util::contained_path(config.web.static_dir.as_std_path(), domain, path)?;
 
     if file_path.exists() {
         tokio::fs::remove_file(&file_path)
@@ -783,9 +800,18 @@ async fn store_content(storage_dir: &PathBuf, content: &[u8]) -> Result<String> 
         .map_err(|e| miette::miette!("Failed to create storage directory: {e}"))?;
 
     if !file_path.exists() {
-        fs::write(&file_path, content)
+        // write to a temp file then atomically rename, so a crash mid-write can
+        // never leave a truncated file under the content hash (which the
+        // exists() check would otherwise treat as valid forever)
+        let temp_path = storage_dir.join(format!(".tmp.{}", uuid::Uuid::new_v4()));
+        fs::write(&temp_path, content)
             .await
             .map_err(|e| miette::miette!("Failed to write file {hash}: {e}"))?;
+
+        if let Err(e) = fs::rename(&temp_path, &file_path).await {
+            let _ = fs::remove_file(&temp_path).await;
+            return Err(miette::miette!("Failed to store file {hash}: {e}"));
+        }
         debug!("Stored new file {hash} ({} bytes)", content.len());
     }
 
@@ -822,9 +848,17 @@ async fn store_content_streaming(
             .await
             .map_err(|e| miette::miette!("Failed to create storage directory: {e}"))?;
 
-        tokio::fs::copy(file_path, &storage_path)
+        // copy to a temp file then atomically rename to avoid leaving a partial
+        // file under the content hash if we crash mid-copy
+        let temp_path = storage_dir.join(format!(".tmp.{}", uuid::Uuid::new_v4()));
+        tokio::fs::copy(file_path, &temp_path)
             .await
             .map_err(|e| miette::miette!("Failed to copy large file to storage: {e}"))?;
+
+        if let Err(e) = tokio::fs::rename(&temp_path, &storage_path).await {
+            let _ = tokio::fs::remove_file(&temp_path).await;
+            return Err(miette::miette!("Failed to store large file {hash}: {e}"));
+        }
 
         debug!(
             "Stored large file {hash} ({} MB)",
@@ -889,31 +923,44 @@ async fn stream_download_and_verify(
         .await
         .map_err(|e| miette::miette!("Failed to create storage directory: {e}"))?;
 
+    // stream into a temp file; only promote to the content-hash path after the
+    // hash is verified, so a partial or corrupt download is never visible
+    let temp_path = storage_dir.join(format!(".tmp.{}", uuid::Uuid::new_v4()));
     let mut stream = response.bytes_stream();
     let mut hasher = Hasher::new();
-    let mut output_file = tokio::fs::File::create(&storage_path)
+    let mut output_file = tokio::fs::File::create(&temp_path)
         .await
         .map_err(|e| miette::miette!("Failed to create storage file: {e}"))?;
 
     while let Some(chunk_result) = stream.next().await {
-        let chunk =
-            chunk_result.map_err(|e| miette::miette!("Failed to read download chunk: {e}"))?;
+        let chunk = match chunk_result {
+            Ok(chunk) => chunk,
+            Err(e) => {
+                let _ = tokio::fs::remove_file(&temp_path).await;
+                return Err(miette::miette!("Failed to read download chunk: {e}"));
+            }
+        };
 
         hasher.update(&chunk);
-        output_file
-            .write_all(&chunk)
-            .await
-            .map_err(|e| miette::miette!("Failed to write download chunk: {e}"))?;
+        if let Err(e) = output_file.write_all(&chunk).await {
+            let _ = tokio::fs::remove_file(&temp_path).await;
+            return Err(miette::miette!("Failed to write download chunk: {e}"));
+        }
     }
 
     let actual_hash = format!("{}", hasher.finalize());
 
     if actual_hash != expected_hash {
         // clean up failed download
-        let _ = tokio::fs::remove_file(&storage_path).await;
+        let _ = tokio::fs::remove_file(&temp_path).await;
         return Err(miette::miette!(
             "Hash mismatch: expected {expected_hash}, got {actual_hash}"
         ));
+    }
+
+    if let Err(e) = tokio::fs::rename(&temp_path, &storage_path).await {
+        let _ = tokio::fs::remove_file(&temp_path).await;
+        return Err(miette::miette!("Failed to store streamed file: {e}"));
     }
 
     debug!("Successfully streamed and verified file {expected_hash}");

--- a/crates/makiatto/src/fs/watcher.rs
+++ b/crates/makiatto/src/fs/watcher.rs
@@ -4,12 +4,12 @@ use std::{path::PathBuf, sync::Arc, time::Duration};
 use blake3::Hasher;
 use futures_util::StreamExt;
 use miette::Result;
-use serde_json::json;
 use notify_debouncer_full::{
     DebounceEventResult, new_debouncer,
     notify::{EventKind, RecursiveMode, event::CreateKind},
 };
 use rand::{RngExt, seq::SliceRandom};
+use serde_json::json;
 use tokio::{
     fs,
     io::{AsyncReadExt, AsyncWriteExt},

--- a/crates/makiatto/src/fs/watcher.rs
+++ b/crates/makiatto/src/fs/watcher.rs
@@ -25,6 +25,19 @@ use crate::{
 
 const STREAMING_THRESHOLD: u64 = 100 * 1024 * 1024; // 100MB
 
+/// Filename prefix used for the daemon's own temporary files (atomic
+/// hardlink/copy staging). These live briefly inside the watched `static_dir`,
+/// so the watcher must ignore them — otherwise it would react to its own writes
+/// and churn (or delete) the very files it just created.
+const TEMP_FILE_PREFIX: &str = ".makiatto-tmp.";
+
+/// Returns true if `path` is one of the daemon's internal temp files.
+pub(crate) fn is_temp_file(path: &std::path::Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.starts_with(TEMP_FILE_PREFIX))
+}
+
 /// File watcher service that monitors `static_dir` for changes
 ///
 /// # Errors
@@ -98,6 +111,12 @@ async fn handle_debounced_events(
         let Some(path) = event.paths.first() else {
             continue;
         };
+
+        // ignore our own staging temp files; reacting to them would make the
+        // watcher chase its own hardlink/copy writes and churn real files
+        if is_temp_file(path) {
+            continue;
+        }
 
         match event.kind {
             EventKind::Create(CreateKind::File) => {
@@ -222,6 +241,11 @@ pub async fn process_file_change(
     static_dir: &std::path::Path,
     storage_dir: &std::path::Path,
 ) -> Result<Option<File>> {
+    // never track our own staging temp files
+    if is_temp_file(file_path) {
+        return Ok(None);
+    }
+
     if !file_path.is_file() {
         return Ok(None);
     }
@@ -693,7 +717,7 @@ async fn create_hardlink(source: &std::path::Path, target: &std::path::Path) -> 
         // place the temp file in the *target's* directory so the final rename is
         // always within one filesystem (avoids EXDEV when storage and the site
         // directory live on different filesystems)
-        let temp_filename = format!(".tmp.{}", uuid::Uuid::new_v4());
+        let temp_filename = format!("{TEMP_FILE_PREFIX}{}", uuid::Uuid::new_v4());
 
         let temp_path = target
             .parent()
@@ -803,7 +827,7 @@ async fn store_content(storage_dir: &PathBuf, content: &[u8]) -> Result<String> 
         // write to a temp file then atomically rename, so a crash mid-write can
         // never leave a truncated file under the content hash (which the
         // exists() check would otherwise treat as valid forever)
-        let temp_path = storage_dir.join(format!(".tmp.{}", uuid::Uuid::new_v4()));
+        let temp_path = storage_dir.join(format!("{TEMP_FILE_PREFIX}{}", uuid::Uuid::new_v4()));
         fs::write(&temp_path, content)
             .await
             .map_err(|e| miette::miette!("Failed to write file {hash}: {e}"))?;
@@ -850,7 +874,7 @@ async fn store_content_streaming(
 
         // copy to a temp file then atomically rename to avoid leaving a partial
         // file under the content hash if we crash mid-copy
-        let temp_path = storage_dir.join(format!(".tmp.{}", uuid::Uuid::new_v4()));
+        let temp_path = storage_dir.join(format!("{TEMP_FILE_PREFIX}{}", uuid::Uuid::new_v4()));
         tokio::fs::copy(file_path, &temp_path)
             .await
             .map_err(|e| miette::miette!("Failed to copy large file to storage: {e}"))?;
@@ -925,7 +949,7 @@ async fn stream_download_and_verify(
 
     // stream into a temp file; only promote to the content-hash path after the
     // hash is verified, so a partial or corrupt download is never visible
-    let temp_path = storage_dir.join(format!(".tmp.{}", uuid::Uuid::new_v4()));
+    let temp_path = storage_dir.join(format!("{TEMP_FILE_PREFIX}{}", uuid::Uuid::new_v4()));
     let mut stream = response.bytes_stream();
     let mut hasher = Hasher::new();
     let mut output_file = tokio::fs::File::create(&temp_path)

--- a/crates/makiatto/src/fs/watcher.rs
+++ b/crates/makiatto/src/fs/watcher.rs
@@ -701,6 +701,30 @@ fn should_fallback_to_copy(err: &std::io::Error) -> bool {
     }
 }
 
+/// Check if an IO error is a cross-device (EXDEV) failure.
+fn is_cross_device(err: &std::io::Error) -> bool {
+    err.kind() == std::io::ErrorKind::CrossesDevices || err.raw_os_error() == Some(18)
+}
+
+/// Copy `source` directly over `target`, overwriting it in place.
+///
+/// Used as the cross-filesystem fallback when an atomic hardlink+rename isn't
+/// possible. This overwrites the existing target's contents (rather than
+/// swapping it via rename), which keeps the change confined to a single
+/// in-place modification the file watcher can safely ignore as a no-op.
+async fn copy_over(source: &std::path::Path, target: &std::path::Path) -> Result<()> {
+    tokio::fs::copy(source, target)
+        .await
+        .map(|_| ())
+        .map_err(|e| {
+            miette::miette!(
+                "Failed to copy {} over {}: {e}",
+                source.display(),
+                target.display()
+            )
+        })
+}
+
 /// Create hardlink with fallback to copy for cross-filesystem scenarios
 async fn create_hardlink(source: &std::path::Path, target: &std::path::Path) -> Result<()> {
     // Check if target already exists and is the same hardlink
@@ -713,13 +737,17 @@ async fn create_hardlink(source: &std::path::Path, target: &std::path::Path) -> 
             return Ok(());
         }
 
-        // file exists but isn't the right hardlink - use atomic rename.
-        // place the temp file in the *target's* directory so the final rename is
-        // always within one filesystem (avoids EXDEV when storage and the site
-        // directory live on different filesystems)
+        // File exists but isn't the right hardlink — replace it atomically.
+        //
+        // Stage the temp hardlink in the SOURCE's (content storage) directory,
+        // which is NOT under the watched static_dir. Renaming from outside the
+        // watched tree produces a single MOVED_TO event for the target and never
+        // a spurious "removed" event. (Staging inside the watched tree made the
+        // file watcher observe the rename as a delete+create and tear down the
+        // file it had just linked.)
         let temp_filename = format!("{TEMP_FILE_PREFIX}{}", uuid::Uuid::new_v4());
 
-        let temp_path = target
+        let temp_path = source
             .parent()
             .unwrap_or(std::path::Path::new("/tmp"))
             .join(temp_filename);
@@ -734,6 +762,14 @@ async fn create_hardlink(source: &std::path::Path, target: &std::path::Path) -> 
                     );
                     Ok(())
                 }
+                Err(ref e) if is_cross_device(e) => {
+                    // storage and the site directory are on different
+                    // filesystems, so the temp hardlink can't be renamed across
+                    // the boundary. Drop it and copy the content directly over
+                    // the target instead (in place, preserving the inode).
+                    let _ = tokio::fs::remove_file(&temp_path).await;
+                    copy_over(source, target).await
+                }
                 Err(e) => {
                     let _ = tokio::fs::remove_file(&temp_path).await;
                     Err(miette::miette!("Failed to rename temp hardlink: {e}"))
@@ -747,17 +783,7 @@ async fn create_hardlink(source: &std::path::Path, target: &std::path::Path) -> 
                     source.display(),
                     target.display()
                 );
-                tokio::fs::copy(source, &temp_path)
-                    .await
-                    .map_err(|e| miette::miette!("Failed to copy file for fallback: {e}"))?;
-
-                match tokio::fs::rename(&temp_path, target).await {
-                    Ok(()) => Ok(()),
-                    Err(e) => {
-                        let _ = tokio::fs::remove_file(&temp_path).await;
-                        Err(miette::miette!("Failed to rename temp file: {e}"))
-                    }
-                }
+                copy_over(source, target).await
             }
             Err(e) => Err(miette::miette!(
                 "Failed to create temp hardlink {}: {e}",

--- a/crates/makiatto/src/main.rs
+++ b/crates/makiatto/src/main.rs
@@ -49,6 +49,9 @@ struct Args {
     only: Option<String>,
 }
 
+/// Max time to wait for services to wind down after a shutdown is requested.
+const SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
 #[allow(clippy::struct_excessive_bools)]
 struct ServiceFlags {
     wireguard: bool,
@@ -312,35 +315,78 @@ async fn main() -> Result<()> {
     let mut sigterm = signal(SignalKind::terminate())
         .map_err(|e| miette::miette!("Failed to setup SIGTERM handler: {e}"))?;
 
+    if handles.is_empty() {
+        tokio::select! {
+            _ = sigterm.recv() => info!("Received SIGTERM, shutting down..."),
+            result = tokio::signal::ctrl_c() => {
+                result.map_err(|e| miette::miette!("Failed to listen for ctrl+c: {e}"))?;
+                info!("Received SIGINT, shutting down...");
+            }
+        }
+        drop(tripwire_worker);
+        return Ok(());
+    }
+
+    // Supervise services with `select_all` so that the FIRST task to exit (clean,
+    // error, or panic) is noticed immediately, rather than waiting for every task
+    // like `join_all` would.
+    let mut services = futures::future::select_all(handles);
+
     tokio::select! {
         _ = sigterm.recv() => {
             info!("Received SIGTERM, shutting down...");
-            drop(tripwire_worker);
         }
         result = tokio::signal::ctrl_c() => {
             match result {
-                Ok(()) => {
-                    info!("Received SIGINT, shutting down...");
-                    drop(tripwire_worker);
-                }
+                Ok(()) => info!("Received SIGINT, shutting down..."),
                 Err(e) => return Err(miette::miette!("Failed to listen for ctrl+c: {e}")),
             }
         }
-        result = futures::future::join_all(handles) => {
-            for (i, res) in result.into_iter().enumerate() {
-                match res {
-                    Ok(Ok(service)) => info!("Service '{service}' stopped cleanly"),
-                    Ok(Err(e)) => {
-                        tracing::error!("Service failed: {e}");
-                        return Err(miette::miette!(e));
-                    }
-                    Err(e) => {
-                        tracing::error!("Service task panicked: {e}");
-                        return Err(miette::miette!("Service task {i} panicked: {e}"));
-                    }
+        (result, idx, rest) = &mut services => {
+            // a service exited on its own — record the outcome, then bring the
+            // rest down gracefully before returning
+            let outcome = match result {
+                Ok(Ok(service)) => {
+                    info!("Service '{service}' stopped cleanly");
+                    Ok(())
                 }
+                Ok(Err(e)) => {
+                    error!("Service failed: {e}");
+                    Err(miette::miette!(e))
+                }
+                Err(e) => {
+                    error!("Service task panicked: {e}");
+                    Err(miette::miette!("Service task {idx} panicked: {e}"))
+                }
+            };
+
+            drop(tripwire_worker);
+            if tokio::time::timeout(SHUTDOWN_TIMEOUT, futures::future::join_all(rest))
+                .await
+                .is_err()
+            {
+                error!("Timed out waiting for remaining services to stop");
+            }
+            return outcome;
+        }
+    }
+
+    // a signal was received: trip the shutdown and wait for services to finish so
+    // cleanup (e.g. wireguard::cleanup_interface) can run, bounded by a timeout
+    drop(tripwire_worker);
+
+    match tokio::time::timeout(SHUTDOWN_TIMEOUT, services).await {
+        Ok((_result, _idx, rest)) => {
+            if tokio::time::timeout(SHUTDOWN_TIMEOUT, futures::future::join_all(rest))
+                .await
+                .is_err()
+            {
+                error!("Timed out waiting for remaining services to stop");
             }
             info!("All services stopped");
+        }
+        Err(_) => {
+            error!("Timed out waiting for services to stop cleanly");
         }
     }
 

--- a/crates/makiatto/src/util.rs
+++ b/crates/makiatto/src/util.rs
@@ -1,3 +1,4 @@
+use std::path::{Component, Path, PathBuf};
 use std::time::SystemTime;
 
 use miette::Result;
@@ -11,4 +12,102 @@ pub fn get_current_timestamp() -> Result<i64> {
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|e| miette::miette!("Failed to get current time: {e}"))?
         .as_secs() as i64)
+}
+
+/// Extract the host portion of a `Host`-header value, dropping any port and
+/// IPv6 brackets. Never panics on malformed input.
+#[must_use]
+pub fn host_without_port(host: &str) -> &str {
+    if let Some(rest) = host.strip_prefix('[') {
+        // bracketed IPv6: `[::1]` or `[::1]:443`
+        return rest.split(']').next().unwrap_or(rest);
+    }
+
+    match host.rsplit_once(':') {
+        // a single colon means host:port; a bare IPv6 has multiple colons and
+        // is returned unchanged
+        Some((h, _)) if !h.contains(':') => h,
+        _ => host,
+    }
+}
+
+/// Validate that `domain` is a single, safe path segment.
+#[must_use]
+pub fn is_safe_domain(domain: &str) -> bool {
+    !domain.is_empty()
+        && domain != "."
+        && domain != ".."
+        && !domain.contains('/')
+        && !domain.contains('\\')
+        && !domain.contains('\0')
+}
+
+/// Join a peer- or client-controlled `domain` and `path` under `base`, rejecting
+/// any input that would escape the `base/domain` directory.
+///
+/// `path` is treated as relative (a leading `/` is stripped). Any `..`
+/// component, absolute root, NUL byte, or unsafe `domain` segment is rejected so
+/// the result is always contained within `base/domain`.
+///
+/// # Errors
+/// Returns an error if the inputs would traverse outside `base/domain`.
+pub fn contained_path(base: &Path, domain: &str, path: &str) -> Result<PathBuf> {
+    if !is_safe_domain(domain) {
+        return Err(miette::miette!("Invalid domain component: {domain:?}"));
+    }
+
+    if path.contains('\0') {
+        return Err(miette::miette!("Path contains NUL byte"));
+    }
+
+    let domain_root = base.join(domain);
+    let mut result = domain_root.clone();
+
+    for component in Path::new(path.trim_start_matches('/')).components() {
+        match component {
+            Component::Normal(part) => result.push(part),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                return Err(miette::miette!("Path traversal rejected in {path:?}"));
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(miette::miette!("Absolute path rejected in {path:?}"));
+            }
+        }
+    }
+
+    // belt-and-braces: the lexical result must remain under the domain root
+    if !result.starts_with(&domain_root) {
+        return Err(miette::miette!("Resolved path escapes domain root"));
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contained_path_allows_normal_paths() {
+        let base = Path::new("/srv/sites");
+        let p = contained_path(base, "example.com", "/css/app.css").unwrap();
+        assert_eq!(p, Path::new("/srv/sites/example.com/css/app.css"));
+    }
+
+    #[test]
+    fn contained_path_rejects_traversal() {
+        let base = Path::new("/srv/sites");
+        assert!(contained_path(base, "example.com", "../../etc/passwd").is_err());
+        assert!(contained_path(base, "../../etc", "passwd").is_err());
+        assert!(contained_path(base, "example.com", "/a/../../b").is_err());
+    }
+
+    #[test]
+    fn contained_path_rejects_bad_domain() {
+        let base = Path::new("/srv/sites");
+        assert!(contained_path(base, "..", "index.html").is_err());
+        assert!(contained_path(base, "a/b", "index.html").is_err());
+        assert!(contained_path(base, "", "index.html").is_err());
+    }
 }

--- a/crates/makiatto/src/util.rs
+++ b/crates/makiatto/src/util.rs
@@ -110,4 +110,45 @@ mod tests {
         assert!(contained_path(base, "a/b", "index.html").is_err());
         assert!(contained_path(base, "", "index.html").is_err());
     }
+
+    #[test]
+    fn contained_path_rejects_nul_and_absolute() {
+        let base = Path::new("/srv/sites");
+        assert!(contained_path(base, "example.com", "/etc/passwd\0").is_err());
+        assert!(contained_path(base, "example.com", "/a/b").is_ok()); // leading slash is stripped
+    }
+
+    #[test]
+    fn host_without_port_strips_port() {
+        assert_eq!(host_without_port("example.com"), "example.com");
+        assert_eq!(host_without_port("example.com:443"), "example.com");
+        assert_eq!(host_without_port("example.com:80"), "example.com");
+    }
+
+    #[test]
+    fn host_without_port_handles_ipv6() {
+        assert_eq!(host_without_port("[::1]:443"), "::1");
+        assert_eq!(host_without_port("[2001:db8::1]"), "2001:db8::1");
+        // a bare IPv6 (multiple colons, no brackets) is returned unchanged
+        assert_eq!(host_without_port("2001:db8::1"), "2001:db8::1");
+    }
+
+    #[test]
+    fn host_without_port_never_panics_on_malformed() {
+        // the values that previously panicked the request handler
+        let _ = host_without_port("x:notaport");
+        let _ = host_without_port("[::1]:80");
+        let _ = host_without_port(":");
+        let _ = host_without_port("");
+    }
+
+    #[test]
+    fn is_safe_domain_rejects_traversal() {
+        assert!(is_safe_domain("example.com"));
+        assert!(!is_safe_domain(".."));
+        assert!(!is_safe_domain("../etc"));
+        assert!(!is_safe_domain("a/b"));
+        assert!(!is_safe_domain(""));
+        assert!(!is_safe_domain("a\0b"));
+    }
 }

--- a/crates/makiatto/src/web/axum.rs
+++ b/crates/makiatto/src/web/axum.rs
@@ -603,9 +603,7 @@ async fn path_exists(path: &Path) -> bool {
 
 /// Async regular-file check (avoids blocking the runtime with `std::fs`).
 async fn path_is_file(path: &Path) -> bool {
-    tokio::fs::metadata(path)
-        .await
-        .is_ok_and(|m| m.is_file())
+    tokio::fs::metadata(path).await.is_ok_and(|m| m.is_file())
 }
 
 fn get_cache_control(path: &str) -> HeaderValue {
@@ -662,7 +660,9 @@ async fn caching_middleware(request: Request, next: Next) -> impl IntoResponse {
 
     if too_large_to_buffer {
         let (mut parts, body) = response.into_parts();
-        parts.headers.insert(CACHE_CONTROL, get_cache_control(&path));
+        parts
+            .headers
+            .insert(CACHE_CONTROL, get_cache_control(&path));
         return (parts, body).into_response();
     }
 

--- a/crates/makiatto/src/web/axum.rs
+++ b/crates/makiatto/src/web/axum.rs
@@ -9,10 +9,10 @@ use std::{
 use axum::{
     Router,
     body::Body,
-    extract::{Path as ExtractPath, Request, State},
+    extract::{DefaultBodyLimit, Path as ExtractPath, Request, State},
     http::{
         HeaderMap, HeaderValue, StatusCode, Uri,
-        header::{CACHE_CONTROL, CONTENT_TYPE, ETAG, IF_NONE_MATCH},
+        header::{CACHE_CONTROL, CONTENT_LENGTH, CONTENT_TYPE, ETAG, IF_NONE_MATCH},
     },
     middleware::{self, Next},
     response::{IntoResponse, Redirect, Response},
@@ -49,6 +49,15 @@ use crate::{
     },
 };
 
+/// Maximum request body size accepted by the server (protects against memory
+/// exhaustion from oversized uploads / WASM function request bodies).
+const MAX_REQUEST_BODY_BYTES: usize = 16 * 1024 * 1024; // 16 MiB
+
+/// Largest response body we will buffer in memory to compute a `CRC32` `ETag`.
+/// Larger responses are streamed straight through without an `ETag` rather than
+/// being held entirely in memory.
+const MAX_ETAG_BODY_BYTES: usize = 8 * 1024 * 1024; // 8 MiB
+
 #[derive(Clone)]
 pub(crate) struct WebState {
     pub(crate) config: Arc<Config>,
@@ -72,22 +81,31 @@ async fn handle_request(
     span.record("http.method", &method);
     span.record("http.target", &uri);
 
-    let (hostname, _port) = host
-        .split_once(':')
-        .map_or((host.as_str(), 80u16), |(hostname, port_str)| {
-            (hostname.as_str(), port_str.parse::<u16>().unwrap())
-        });
+    // parse the host without panicking on a malformed/IPv6/odd-port value
+    let hostname = crate::util::host_without_port(&host);
 
     // resolve domain alias if exists
     let resolved_domain = resolve_cname(&state.cname_map, hostname);
-    let domain_path = state.static_dir.join(&resolved_domain);
 
-    if !domain_path.exists() {
-        span.record("error", format!("Domain '{resolved_domain}' not found"));
-
+    // the resolved domain becomes a path segment under static_dir — reject any
+    // value that could escape the content root (e.g. `Host: ../../etc`)
+    if !crate::util::is_safe_domain(&resolved_domain) {
+        span.record("error", format!("Invalid host '{resolved_domain}'"));
         return Response::builder()
             .status(StatusCode::NOT_FOUND)
-            .body(Body::from(format!("'{hostname:?}' not found")))
+            .body(Body::from("Not found"))
+            .unwrap();
+    }
+
+    let domain_path = state.static_dir.join(&resolved_domain);
+
+    if !path_exists(&domain_path).await {
+        span.record("error", format!("Domain '{resolved_domain}' not found"));
+
+        // do not reflect the attacker-controlled host back in the body
+        return Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Body::from("Not found"))
             .unwrap();
     }
 
@@ -96,7 +114,7 @@ async fn handle_request(
     let final_request = {
         let requested_file = domain_path.join(uri_path.trim_start_matches('/'));
 
-        if requested_file.exists() && requested_file.is_file() {
+        if path_is_file(&requested_file).await {
             // original path exists, use as-is
             request
         } else {
@@ -106,7 +124,7 @@ async fn handle_request(
 
             for fallback_path in &fallback_paths {
                 let fallback_file = domain_path.join(fallback_path.trim_start_matches('/'));
-                if fallback_file.exists() && fallback_file.is_file() {
+                if path_is_file(&fallback_file).await {
                     debug!("Using fallback: {} -> {}", uri_path, fallback_path);
                     found_fallback = Some(fallback_path);
                     break;
@@ -209,25 +227,31 @@ async fn image_middleware(
 
     span.record("has_params", true);
 
-    let (hostname, _port) = host
-        .split_once(':')
-        .map_or((host.as_str(), 80u16), |(hostname, port_str)| {
-            (hostname, port_str.parse::<u16>().unwrap_or(80))
-        });
+    let hostname = crate::util::host_without_port(&host);
 
     let resolved_domain = resolve_cname(&state.cname_map, hostname);
+
+    if !crate::util::is_safe_domain(&resolved_domain) {
+        return next.run(request).await;
+    }
+
     let domain_path = state.static_dir.join(&resolved_domain);
 
-    if !domain_path.exists() {
+    if !path_exists(&domain_path).await {
         return next.run(request).await;
     }
 
     let uri_path = request.uri().path();
-    let file_path = domain_path.join(uri_path.trim_start_matches('/'));
-
     span.record("path", uri_path);
 
-    if !file_path.exists() || !file_path.is_file() {
+    // this middleware reads the file directly (bypassing ServeDir's traversal
+    // protection), so contain the path under the domain root ourselves
+    let Ok(file_path) = crate::util::contained_path(&state.static_dir, &resolved_domain, uri_path)
+    else {
+        return next.run(request).await;
+    };
+
+    if !path_is_file(&file_path).await {
         return next.run(request).await;
     }
 
@@ -363,6 +387,9 @@ pub async fn start(
     config: Arc<Config>,
     mut shutdown_rx: tokio::sync::mpsc::Receiver<()>,
 ) -> Result<()> {
+    // honour the configured trust policy for forwarded host headers
+    crate::web::extract::host::set_trust_forwarded_host(config.web.trust_forwarded_host);
+
     let mut cname_cache = HashMap::new();
 
     // load initial domain aliases
@@ -457,6 +484,7 @@ pub async fn start(
         .layer(ConcurrencyLimitLayer::new(
             config.web.max_concurrent_requests,
         ))
+        .layer(DefaultBodyLimit::max(MAX_REQUEST_BODY_BYTES))
         .with_state(state.clone());
 
     let http_addr: SocketAddr = config
@@ -568,6 +596,18 @@ pub async fn start(
     Ok(())
 }
 
+/// Async existence check (avoids blocking the runtime with `std::fs`).
+async fn path_exists(path: &Path) -> bool {
+    tokio::fs::try_exists(path).await.unwrap_or(false)
+}
+
+/// Async regular-file check (avoids blocking the runtime with `std::fs`).
+async fn path_is_file(path: &Path) -> bool {
+    tokio::fs::metadata(path)
+        .await
+        .is_ok_and(|m| m.is_file())
+}
+
 fn get_cache_control(path: &str) -> HeaderValue {
     let extension = Path::new(path)
         .extension()
@@ -610,9 +650,25 @@ async fn caching_middleware(request: Request, next: Next) -> impl IntoResponse {
         return response;
     }
 
+    // Skip ETag computation for large or unknown-length bodies so we never
+    // buffer an arbitrarily large response in memory just to hash it. Such
+    // responses are streamed straight through (still with Cache-Control).
+    let too_large_to_buffer = response
+        .headers()
+        .get(CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+        .is_none_or(|len| len > MAX_ETAG_BODY_BYTES as u64);
+
+    if too_large_to_buffer {
+        let (mut parts, body) = response.into_parts();
+        parts.headers.insert(CACHE_CONTROL, get_cache_control(&path));
+        return (parts, body).into_response();
+    }
+
     let (mut parts, body) = response.into_parts();
 
-    let Ok(body_bytes) = axum::body::to_bytes(body, usize::MAX).await else {
+    let Ok(body_bytes) = axum::body::to_bytes(body, MAX_ETAG_BODY_BYTES).await else {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             "Failed to read response body",

--- a/crates/makiatto/src/web/certificate.rs
+++ b/crates/makiatto/src/web/certificate.rs
@@ -270,35 +270,47 @@ impl CertificateManager {
 
         let next_check = now + self.config.acme.check_interval as i64;
 
-        let sql = format!(
+        let sql = corrosion::Statement::with_params(
             r"INSERT OR REPLACE INTO certificate_renewals
             (domain, last_check, renewal_status, next_check, retry_count, last_renewal)
-            VALUES ('{domain}', {now}, '{status}', {next_check},
-                COALESCE((SELECT retry_count FROM certificate_renewals WHERE domain = '{domain}'), 0),
-                CASE WHEN '{status}' = 'completed' THEN {now} ELSE
-                    (SELECT last_renewal FROM certificate_renewals WHERE domain = '{domain}')
+            VALUES (?, ?, ?, ?,
+                COALESCE((SELECT retry_count FROM certificate_renewals WHERE domain = ?), 0),
+                CASE WHEN ? = 'completed' THEN ? ELSE
+                    (SELECT last_renewal FROM certificate_renewals WHERE domain = ?)
                 END
             )",
+            vec![
+                serde_json::json!(domain),
+                serde_json::json!(now),
+                serde_json::json!(status),
+                serde_json::json!(next_check),
+                serde_json::json!(domain),
+                serde_json::json!(status),
+                serde_json::json!(now),
+                serde_json::json!(domain),
+            ],
         );
 
         corrosion::execute_transactions(&[sql]).await
     }
 
     async fn increment_retry_count(&self, domain: &str) -> Result<()> {
-        let sql = format!(
+        let sql = corrosion::Statement::with_params(
             r"UPDATE certificate_renewals
             SET retry_count = retry_count + 1
-            WHERE domain = '{domain}'",
+            WHERE domain = ?",
+            vec![serde_json::json!(domain)],
         );
 
         corrosion::execute_transactions(&[sql]).await
     }
 
     async fn reset_retry_count(&self, domain: &str) -> Result<()> {
-        let sql = format!(
+        let sql = corrosion::Statement::with_params(
             r"UPDATE certificate_renewals
             SET retry_count = 0
-            WHERE domain = '{domain}'",
+            WHERE domain = ?",
+            vec![serde_json::json!(domain)],
         );
 
         corrosion::execute_transactions(&[sql]).await

--- a/crates/makiatto/src/web/certificate/acme.rs
+++ b/crates/makiatto/src/web/certificate/acme.rs
@@ -5,21 +5,36 @@ use instant_acme::{
     Account, ChallengeType, Identifier, LetsEncrypt, NewAccount, NewOrder, OrderStatus, RetryPolicy,
 };
 use miette::{IntoDiagnostic, Result};
+use tokio::sync::Mutex;
 use tokio::time::sleep;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::config::Config;
 use crate::corrosion::{self, schema::Certificate};
 
-#[derive(Debug)]
+/// How long to wait for a stored challenge to become readable before proceeding.
+const CHALLENGE_VISIBILITY_TIMEOUT: Duration = Duration::from_secs(15);
+
 pub struct AcmeClient {
     config: Arc<Config>,
+    /// Cached ACME account, reused for the lifetime of the process to avoid
+    /// registering a brand-new account on every certificate order.
+    account: Mutex<Option<Account>>,
+}
+
+impl std::fmt::Debug for AcmeClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AcmeClient").finish_non_exhaustive()
+    }
 }
 
 impl AcmeClient {
     #[must_use]
     pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
+        Self {
+            config,
+            account: Mutex::new(None),
+        }
     }
 
     /// Order a certificate from Let's Encrypt
@@ -40,6 +55,8 @@ impl AcmeClient {
             .await
             .into_diagnostic()?;
 
+        let mut challenge_tokens = Vec::new();
+
         let mut authorizations = order.authorizations();
         while let Some(result) = authorizations.next().await {
             let mut authz = result.into_diagnostic()?;
@@ -53,8 +70,12 @@ impl AcmeClient {
             let key_auth_string = key_auth.as_str();
             self.store_acme_challenge(&token, key_auth_string).await?;
 
-            sleep(Duration::from_secs(2)).await;
+            // wait until the challenge is actually readable before telling the CA
+            // to validate, rather than a blind fixed sleep that races propagation
+            self.wait_for_challenge_visible(&token).await;
+
             challenge.set_ready().await.into_diagnostic()?;
+            challenge_tokens.push(token);
         }
 
         let retry_policy = RetryPolicy::new()
@@ -65,6 +86,8 @@ impl AcmeClient {
         let status = order.poll_ready(&retry_policy).await.into_diagnostic()?;
 
         if status != OrderStatus::Ready {
+            // best-effort cleanup of challenge tokens we created for this order
+            self.cleanup_challenges(&challenge_tokens).await;
             return Err(miette::miette!("Order validation failed: {status:?}"));
         }
 
@@ -73,6 +96,9 @@ impl AcmeClient {
             .poll_certificate(&retry_policy)
             .await
             .into_diagnostic()?;
+
+        // challenge has served its purpose; remove the tokens from the cluster
+        self.cleanup_challenges(&challenge_tokens).await;
 
         // Calculate expiration (90 days for Let's Encrypt)
         let expires_at = SystemTime::now()
@@ -105,10 +131,16 @@ impl AcmeClient {
 
         let expires_at = now + 300; // 5 minutes
 
-        let sql = format!(
+        let sql = corrosion::Statement::with_params(
             r"INSERT OR REPLACE INTO acme_challenges
             (token, key_authorisation, created_at, expires_at)
-            VALUES ('{token}', '{key_auth}', {now}, {expires_at})",
+            VALUES (?, ?, ?, ?)",
+            vec![
+                serde_json::json!(token),
+                serde_json::json!(key_auth),
+                serde_json::json!(now),
+                serde_json::json!(expires_at),
+            ],
         );
 
         corrosion::execute_transactions(&[sql]).await
@@ -119,14 +151,70 @@ impl AcmeClient {
     /// # Errors
     /// Returns an error if database operations fail
     pub async fn delete_acme_challenge(&self, token: &str) -> Result<()> {
-        let sql = format!("DELETE FROM acme_challenges WHERE token = '{token}'");
+        let sql = corrosion::Statement::with_params(
+            "DELETE FROM acme_challenges WHERE token = ?",
+            vec![serde_json::json!(token)],
+        );
         corrosion::execute_transactions(&[sql]).await
     }
 
-    /// Get or create ACME account
+    /// Poll the local database until a freshly stored challenge token is
+    /// readable, so we only ask the CA to validate once the row has committed.
+    ///
+    /// This confirms our own write is queryable and gives gossip a brief window
+    /// to replicate it to peers (the validator may be geo-routed to any node).
+    /// Best-effort: returns after [`CHALLENGE_VISIBILITY_TIMEOUT`] regardless.
+    async fn wait_for_challenge_visible(&self, token: &str) {
+        let start = SystemTime::now();
+
+        loop {
+            match corrosion::get_pool().await {
+                Ok(pool) => {
+                    let row = sqlx::query!(
+                        "SELECT token FROM acme_challenges WHERE token = ?1",
+                        token
+                    )
+                    .fetch_optional(pool)
+                    .await;
+
+                    if matches!(row, Ok(Some(_))) {
+                        // give gossip a brief moment to fan the row out to peers
+                        sleep(Duration::from_secs(2)).await;
+                        return;
+                    }
+                }
+                Err(e) => warn!("Waiting for challenge visibility, pool not ready: {e}"),
+            }
+
+            if start.elapsed().unwrap_or_default() > CHALLENGE_VISIBILITY_TIMEOUT {
+                warn!("Timed out waiting for ACME challenge '{token}' to become visible");
+                return;
+            }
+
+            sleep(Duration::from_millis(500)).await;
+        }
+    }
+
+    /// Best-effort deletion of challenge tokens once they are no longer needed.
+    async fn cleanup_challenges(&self, tokens: &[String]) {
+        for token in tokens {
+            if let Err(e) = self.delete_acme_challenge(token).await {
+                warn!("Failed to delete ACME challenge '{token}': {e}");
+            }
+        }
+    }
+
+    /// Get or create the ACME account, reusing a cached account for the lifetime
+    /// of the process.
+    ///
+    /// Note: the account is not persisted across restarts yet, so a restart will
+    /// register a fresh account on the next order.
     async fn get_or_create_account(&self) -> Result<Account> {
-        // for now, create a new account each time
-        // TODO: store and reuse account credentials
+        let mut cached = self.account.lock().await;
+        if let Some(account) = cached.as_ref() {
+            return Ok(account.clone());
+        }
+
         let directory = if self.config.acme.staging {
             LetsEncrypt::Staging
         } else {
@@ -153,6 +241,7 @@ impl AcmeClient {
             .await
             .into_diagnostic()?;
 
+        *cached = Some(account.clone());
         Ok(account)
     }
 }

--- a/crates/makiatto/src/web/certificate/acme.rs
+++ b/crates/makiatto/src/web/certificate/acme.rs
@@ -170,12 +170,10 @@ impl AcmeClient {
         loop {
             match corrosion::get_pool().await {
                 Ok(pool) => {
-                    let row = sqlx::query!(
-                        "SELECT token FROM acme_challenges WHERE token = ?1",
-                        token
-                    )
-                    .fetch_optional(pool)
-                    .await;
+                    let row =
+                        sqlx::query!("SELECT token FROM acme_challenges WHERE token = ?1", token)
+                            .fetch_optional(pool)
+                            .await;
 
                     if matches!(row, Ok(Some(_))) {
                         // give gossip a brief moment to fan the row out to peers

--- a/crates/makiatto/src/web/certificate/store.rs
+++ b/crates/makiatto/src/web/certificate/store.rs
@@ -99,15 +99,27 @@ impl CertificateStore {
 
     /// Save a certificate to the database and update memory cache
     ///
+    /// Note: the private key is stored base64-encoded but **unencrypted** in the
+    /// replicated `certificates` table, so it is readable by any node in the
+    /// cluster and by anything with access to `cluster.db`. This is inherent to
+    /// the current replication design; protect the database file and the
+    /// `WireGuard` mesh accordingly.
+    ///
     /// # Errors
     /// Returns an error if the database transaction fails
     pub async fn save_certificate(&self, cert: Certificate) -> Result<()> {
         let cert_pem_b64 = BASE64_STANDARD.encode(cert.certificate_pem.as_bytes());
         let key_pem_b64 = BASE64_STANDARD.encode(cert.private_key_pem.as_bytes());
 
-        let sql = format!(
-            "INSERT OR REPLACE INTO certificates (domain, certificate_pem, private_key_pem, expires_at, issuer) VALUES ('{}', '{}', '{}', {}, '{}')",
-            cert.domain, cert_pem_b64, key_pem_b64, cert.expires_at, cert.issuer
+        let sql = corrosion::Statement::with_params(
+            "INSERT OR REPLACE INTO certificates (domain, certificate_pem, private_key_pem, expires_at, issuer) VALUES (?, ?, ?, ?, ?)",
+            vec![
+                serde_json::json!(cert.domain.as_ref()),
+                serde_json::json!(cert_pem_b64),
+                serde_json::json!(key_pem_b64),
+                serde_json::json!(cert.expires_at),
+                serde_json::json!(cert.issuer.as_ref()),
+            ],
         );
 
         // update memory cache
@@ -162,7 +174,13 @@ impl CertificateStore {
         let mut certified_keys = HashMap::new();
         let mut default_cert = None;
 
-        for (domain, cert) in certificates.iter() {
+        // iterate in a stable (sorted) order so the chosen default certificate is
+        // deterministic across restarts rather than depending on HashMap ordering
+        let mut domains: Vec<&String> = certificates.keys().collect();
+        domains.sort();
+
+        for domain in domains {
+            let cert = &certificates[domain];
             let cert_chain = load_certs_from_pem(&cert.certificate_pem)
                 .map_err(|e| miette::miette!("Failed to parse PEM for {domain}: {e}"))?;
 

--- a/crates/makiatto/src/web/dns.rs
+++ b/crates/makiatto/src/web/dns.rs
@@ -95,26 +95,23 @@ impl Handler {
         match tag {
             Property::Issue => Some(rdata::CAA::new_issue(
                 issuer_critical,
-                Some(Name::from_str_relaxed(value).unwrap()),
+                Some(Name::from_str_relaxed(value).ok()?),
                 Vec::new(),
             )),
             Property::IssueWild => Some(rdata::CAA::new_issuewild(
                 issuer_critical,
-                Some(Name::from_str_relaxed(value).unwrap()),
+                Some(Name::from_str_relaxed(value).ok()?),
                 Vec::new(),
             )),
-            Property::Iodef => Some(rdata::CAA::new_iodef(
-                issuer_critical,
-                Url::parse(value).unwrap(),
-            )),
+            Property::Iodef => Some(rdata::CAA::new_iodef(issuer_critical, Url::parse(value).ok()?)),
             Property::Unknown(_) => None,
         }
     }
 
     fn soa_from_string(input: &str) -> Option<rdata::SOA> {
         let mut parts = input.split_whitespace();
-        let mname = Name::from_str_relaxed(parts.next()?).unwrap();
-        let rname = Name::from_str_relaxed(parts.next()?).unwrap();
+        let mname = Name::from_str_relaxed(parts.next()?).ok()?;
+        let rname = Name::from_str_relaxed(parts.next()?).ok()?;
         let serial = parts.next()?.parse().ok()?;
         let refresh = parts.next()?.parse().ok()?;
         let retry = parts.next()?.parse().ok()?;
@@ -131,44 +128,38 @@ impl Handler {
         let priority = parts.next()?.parse().ok()?;
         let weight = parts.next()?.parse().ok()?;
         let port = parts.next()?.parse().ok()?;
-        let target = Name::from_str_relaxed(parts.next()?).unwrap();
+        let target = Name::from_str_relaxed(parts.next()?).ok()?;
 
         Some(rdata::SRV::new(priority, weight, port, target))
     }
 
+    /// Build a DNS record from stored values, returning `None` for any malformed
+    /// value rather than panicking. A single bad replicated record must never be
+    /// able to crash the daemon when its name is queried.
     fn generate_record(
         name: &LowerName,
         record_type: &str,
         value: &str,
         ttl: u32,
         preference: Option<i32>,
-    ) -> Record {
-        let rdata: Option<RData> = match record_type {
-            "A" => Some(RData::A(rdata::A(Ipv4Addr::from_str(value).unwrap()))),
-            "AAAA" => Some(RData::AAAA(rdata::AAAA(Ipv6Addr::from_str(value).unwrap()))),
-            "CAA" => Some(RData::CAA(Self::caa_from_string(value).unwrap())),
-            "CNAME" => Some(RData::CNAME(rdata::CNAME(
-                Name::from_str_relaxed(value).unwrap(),
-            ))),
-            "MX" => Some(RData::MX(MX::new(
-                preference
-                    .expect("preference needs MX record")
-                    .try_into()
-                    .unwrap(),
-                Name::from_str_relaxed(value).unwrap(),
-            ))),
-            "NS" => Some(RData::NS(rdata::NS(Name::from_str_relaxed(value).unwrap()))),
-            "SOA" => Some(RData::SOA(
-                Self::soa_from_string(value).expect("Should be a valid SOA record"),
+    ) -> Option<Record> {
+        let rdata: RData = match record_type {
+            "A" => RData::A(rdata::A(Ipv4Addr::from_str(value).ok()?)),
+            "AAAA" => RData::AAAA(rdata::AAAA(Ipv6Addr::from_str(value).ok()?)),
+            "CAA" => RData::CAA(Self::caa_from_string(value)?),
+            "CNAME" => RData::CNAME(rdata::CNAME(Name::from_str_relaxed(value).ok()?)),
+            "MX" => RData::MX(MX::new(
+                preference?.try_into().ok()?,
+                Name::from_str_relaxed(value).ok()?,
             )),
-            "SRV" => Some(RData::SRV(
-                Self::srv_from_string(value).expect("Should be a valid SRV record"),
-            )),
-            "TXT" => Some(RData::TXT(TXT::new(vec![value.to_string()]))),
-            _ => None,
+            "NS" => RData::NS(rdata::NS(Name::from_str_relaxed(value).ok()?)),
+            "SOA" => RData::SOA(Self::soa_from_string(value)?),
+            "SRV" => RData::SRV(Self::srv_from_string(value)?),
+            "TXT" => RData::TXT(TXT::new(vec![value.to_string()])),
+            _ => return None,
         };
 
-        Record::from_rdata(name.into(), ttl, rdata.expect("Invalid record type"))
+        Some(Record::from_rdata(name.into(), ttl, rdata))
     }
 
     /// Returns `(records, country_code)` where `country_code` is the ISO country code from `GeoIP`.
@@ -202,7 +193,8 @@ impl Handler {
                         .country
                         .iso_code
                         .map_or_else(|| "unknown".to_string(), String::from);
-                    (point!(x: lat, y: lon), country_code)
+                    // geo's Haversine expects x = longitude, y = latitude
+                    (point!(x: lon, y: lat), country_code)
                 }
                 Ok(None) => {
                     debug!("GeoIP lookup found no data for IP");
@@ -247,34 +239,36 @@ impl Handler {
             .iter()
             .filter(|record| record.record_type.as_ref() == effective_query_type)
             .filter_map(|record| {
-                if !record.geo_enabled {
-                    return Some(Self::generate_record(
-                        &request.name,
-                        &record.record_type,
-                        &record.value,
-                        record.ttl,
-                        Some(record.priority),
-                    ));
-                }
-
-                let peer = closest_peer?;
-
-                let value = match record.record_type.as_str() {
-                    "A" => &peer.ipv4,
-                    "AAAA" => match &peer.ipv6 {
-                        Some(ipv6) if !ipv6.is_empty() => ipv6,
-                        Some(_) | None => return None,
-                    },
-                    _ => &record.value,
+                let value = if record.geo_enabled {
+                    let peer = closest_peer?;
+                    match record.record_type.as_str() {
+                        "A" => peer.ipv4.as_ref(),
+                        "AAAA" => match &peer.ipv6 {
+                            Some(ipv6) if !ipv6.is_empty() => ipv6.as_ref(),
+                            Some(_) | None => return None,
+                        },
+                        _ => record.value.as_ref(),
+                    }
+                } else {
+                    record.value.as_ref()
                 };
 
-                Some(Self::generate_record(
+                let record_out = Self::generate_record(
                     &request.name,
                     &record.record_type,
                     value,
                     record.ttl,
                     Some(record.priority),
-                ))
+                );
+
+                if record_out.is_none() {
+                    warn!(
+                        "Skipping malformed {} record for '{}': value {:?}",
+                        record.record_type, lookup_name, value
+                    );
+                }
+
+                record_out
             })
             .collect();
 
@@ -291,6 +285,10 @@ impl Handler {
     ) {
         let meter = global::meter("dns");
 
+        // the records map is keyed without a trailing dot, but query names from
+        // the wire are fully-qualified (trailing dot) — normalise before lookup
+        let lookup_name = query_name.trim_end_matches('.');
+
         let attributes = vec![
             KeyValue::new("query_type", query_type.to_string()),
             KeyValue::new("response_code", response_code.to_string()),
@@ -298,7 +296,7 @@ impl Handler {
             KeyValue::new(
                 "geo_enabled",
                 self.records
-                    .get(query_name)
+                    .get(lookup_name)
                     .is_some_and(|records| records.iter().any(|r| r.geo_enabled))
                     .to_string(),
             ),
@@ -321,7 +319,7 @@ impl Handler {
 
         if self
             .records
-            .get(query_name)
+            .get(lookup_name)
             .is_some_and(|records| records.iter().any(|r| r.geo_enabled))
         {
             let peer_gauge = meter
@@ -346,19 +344,32 @@ impl RequestHandler for Handler {
         mut handler: R,
     ) -> ResponseInfo {
         let start_time = std::time::Instant::now();
-        let query_name = request
-            .queries()
-            .first()
-            .map(|q| q.name().to_string())
-            .unwrap_or_default();
-        let query_type = request
-            .queries()
-            .first()
-            .map(|q| q.query_type().to_string())
-            .unwrap_or_default();
         let client_ip = request.src().ip();
 
         let span = tracing::Span::current();
+
+        // A datagram with no question section (qdcount = 0) has no first query.
+        // Returning FORMERR here instead of unwrapping avoids aborting the whole
+        // daemon (panic = "abort") on a single malformed UDP packet.
+        let Some(query) = request.queries().first() else {
+            warn!("Received DNS request with no question section from {client_ip}");
+            let mut header = Header::response_from_request(request.header());
+            header.set_response_code(ResponseCode::FormErr);
+            let builder = MessageResponseBuilder::from_message_request(request);
+            let response = builder.build_no_records(header);
+            return match handler.send_response(response).await {
+                Ok(info) => info,
+                Err(e) => {
+                    error!("Failed to send FORMERR response: {e}");
+                    Self::create_failure_response()
+                }
+            };
+        };
+
+        let query_name = query.name().to_string();
+        let query_type = query.query_type().to_string();
+        let query_name_owned = query.name().clone();
+
         span.record("query_name", &query_name);
         span.record("query_type", &query_type);
 
@@ -366,7 +377,7 @@ impl RequestHandler for Handler {
             op_code: request.op_code(),
             message_type: request.message_type(),
             ip: client_ip,
-            name: request.queries().first().unwrap().name().clone(),
+            name: query_name_owned,
             query_type: query_type.clone(),
         };
 
@@ -463,11 +474,32 @@ pub(crate) async fn download_geolite(path: &Utf8PathBuf) -> Result<()> {
         .await
         .map_err(|e| miette::miette!("Failed to read response body: {e}"))?;
 
-    tokio::fs::write(path, bytes)
-        .await
-        .map_err(|e| miette::miette!("Failed to write GeoLite2 database to {path}: {e}"))?;
+    // Write to a temp file and validate it actually parses as a MaxMind DB
+    // before promoting it. This guards against truncated downloads or an error
+    // page being served in place of the database, and makes the swap atomic.
+    let temp_path = Utf8PathBuf::from(format!("{path}.tmp"));
 
-    info!("GeoLite2 database downloaded successfully");
+    tokio::fs::write(&temp_path, &bytes)
+        .await
+        .map_err(|e| miette::miette!("Failed to write GeoLite2 database to {temp_path}: {e}"))?;
+
+    let validate_path = temp_path.clone();
+    let valid = tokio::task::spawn_blocking(move || Reader::open_readfile(&validate_path).is_ok())
+        .await
+        .unwrap_or(false);
+
+    if !valid {
+        let _ = tokio::fs::remove_file(&temp_path).await;
+        return Err(miette::miette!(
+            "Downloaded GeoLite2 database failed validation (not a valid MaxMind DB)"
+        ));
+    }
+
+    tokio::fs::rename(&temp_path, path).await.map_err(|e| {
+        miette::miette!("Failed to install GeoLite2 database to {path}: {e}")
+    })?;
+
+    info!("GeoLite2 database downloaded and validated successfully");
     Ok(())
 }
 
@@ -494,7 +526,8 @@ pub async fn start(
         .iter()
         .filter(|p| !p.is_external && !unhealthy_nodes.contains(p.name.as_ref()))
         .map(|p| DnsPeer {
-            point: point!(x: p.latitude, y: p.longitude),
+            // geo's Haversine expects x = longitude, y = latitude
+            point: point!(x: p.longitude, y: p.latitude),
             ipv4: p.ipv4.clone(),
             ipv6: p.ipv6.clone(),
         })
@@ -620,10 +653,11 @@ pub async fn start(
         _ = shutdown_rx.recv() => {
             info!("DNS server received shutdown signal");
         }
-        _ = geolite_task => {
-            error!("Geolite task received shutdown signal");
-        }
     }
+
+    // the GeoLite refresh task is a background helper — abort it on shutdown
+    // rather than letting its completion tear the DNS server down
+    geolite_task.abort();
 
     Ok(())
 }

--- a/crates/makiatto/src/web/dns.rs
+++ b/crates/makiatto/src/web/dns.rs
@@ -103,7 +103,10 @@ impl Handler {
                 Some(Name::from_str_relaxed(value).ok()?),
                 Vec::new(),
             )),
-            Property::Iodef => Some(rdata::CAA::new_iodef(issuer_critical, Url::parse(value).ok()?)),
+            Property::Iodef => Some(rdata::CAA::new_iodef(
+                issuer_critical,
+                Url::parse(value).ok()?,
+            )),
             Property::Unknown(_) => None,
         }
     }
@@ -495,9 +498,9 @@ pub(crate) async fn download_geolite(path: &Utf8PathBuf) -> Result<()> {
         ));
     }
 
-    tokio::fs::rename(&temp_path, path).await.map_err(|e| {
-        miette::miette!("Failed to install GeoLite2 database to {path}: {e}")
-    })?;
+    tokio::fs::rename(&temp_path, path)
+        .await
+        .map_err(|e| miette::miette!("Failed to install GeoLite2 database to {path}: {e}"))?;
 
     info!("GeoLite2 database downloaded and validated successfully");
     Ok(())

--- a/crates/makiatto/src/web/extract/host.rs
+++ b/crates/makiatto/src/web/extract/host.rs
@@ -3,6 +3,7 @@
 // See: https://github.com/tokio-rs/axum/issues/3442
 
 use std::convert::Infallible;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use axum::RequestPartsExt;
 use axum::extract::{FromRequestParts, OptionalFromRequestParts};
@@ -13,6 +14,15 @@ use http::{
 };
 
 const X_FORWARDED_HOST_HEADER_KEY: &str = "X-Forwarded-Host";
+
+/// Whether to trust `Forwarded` / `X-Forwarded-Host` headers. Defaults to false
+/// (safe for an internet-facing edge); set from config at server startup.
+pub static TRUST_FORWARDED_HOST: AtomicBool = AtomicBool::new(false);
+
+/// Configure whether forwarded headers are trusted when resolving the host.
+pub fn set_trust_forwarded_host(trust: bool) {
+    TRUST_FORWARDED_HOST.store(trust, Ordering::Relaxed);
+}
 
 #[derive(Debug, Clone)]
 pub struct Host(pub String);
@@ -54,16 +64,21 @@ where
         parts: &mut Parts,
         _state: &S,
     ) -> Result<Option<Self>, Self::Rejection> {
-        if let Some(host) = parse_forwarded(&parts.headers) {
-            return Ok(Some(Self(host.to_owned())));
-        }
+        // Only consult the spoofable forwarded headers when explicitly trusted
+        // (i.e. behind a known reverse proxy). On an internet-facing edge these
+        // are attacker-controlled and must not override the real Host.
+        if TRUST_FORWARDED_HOST.load(Ordering::Relaxed) {
+            if let Some(host) = parse_forwarded(&parts.headers) {
+                return Ok(Some(Self(host.to_owned())));
+            }
 
-        if let Some(host) = parts
-            .headers
-            .get(X_FORWARDED_HOST_HEADER_KEY)
-            .and_then(|host| host.to_str().ok())
-        {
-            return Ok(Some(Self(host.to_owned())));
+            if let Some(host) = parts
+                .headers
+                .get(X_FORWARDED_HOST_HEADER_KEY)
+                .and_then(|host| host.to_str().ok())
+            {
+                return Ok(Some(Self(host.to_owned())));
+            }
         }
 
         if let Some(host) = parts

--- a/crates/makiatto/src/web/extract/host.rs
+++ b/crates/makiatto/src/web/extract/host.rs
@@ -60,6 +60,10 @@ where
 {
     type Rejection = Infallible;
 
+    // The trait method is `async fn`, but resolving the host only reads request
+    // parts synchronously — there is nothing to await. Keep the async signature
+    // to match the trait shape rather than returning an `impl Future`.
+    #[allow(clippy::unused_async_trait_impl)]
     async fn from_request_parts(
         parts: &mut Parts,
         _state: &S,

--- a/crates/makiatto/src/web/image.rs
+++ b/crates/makiatto/src/web/image.rs
@@ -57,13 +57,16 @@ impl ImageProcessor {
     }
 
     /// Check if the request has image transformation parameters
+    ///
+    /// Matches on exact query-parameter keys rather than substrings, so an
+    /// unrelated parameter like `?new=1` (which contains `w=`) does not trigger
+    /// image processing.
     #[must_use]
     pub fn has_transform_params(query: &str) -> bool {
-        query.contains("w=")
-            || query.contains("h=")
-            || query.contains("fmt=")
-            || query.contains("q=")
-            || query.contains("fit=")
+        query.split('&').any(|pair| {
+            let key = pair.split('=').next().unwrap_or("");
+            matches!(key, "w" | "h" | "fmt" | "q" | "fit")
+        })
     }
 
     /// Process an image with the given parameters
@@ -90,12 +93,34 @@ impl ImageProcessor {
 
         debug!("Cache miss for image: {:?}", file_path);
 
+        // bound the source size before decoding to avoid decode-bomb / memory
+        // exhaustion from an unexpectedly large source file
+        let metadata = tokio::fs::metadata(file_path)
+            .await
+            .map_err(|e| ProcessError::IoError(e.to_string()))?;
+
+        if metadata.len() > self.config.max_source_bytes {
+            return Err(ProcessError::InvalidParams(format!(
+                "Source image is too large ({} bytes, max {})",
+                metadata.len(),
+                self.config.max_source_bytes
+            )));
+        }
+
         let image_data = tokio::fs::read(file_path)
             .await
             .map_err(|e| ProcessError::IoError(e.to_string()))?;
 
-        let processed = Self::transform_image(&image_data, &params)?;
+        // content type depends only on the requested params; compute it before
+        // moving params into the blocking task
         let content_type = Self::get_content_type(&params);
+
+        // imageflow is synchronous and CPU-heavy; run it on a blocking thread so
+        // it doesn't stall the async runtime
+        let processed =
+            tokio::task::spawn_blocking(move || Self::transform_image(&image_data, &params))
+                .await
+                .map_err(|e| ProcessError::ImageflowError(format!("Image task failed: {e}")))??;
 
         self.cache
             .insert(cache_key, Arc::new(processed.clone()))

--- a/crates/makiatto/src/web/image.rs
+++ b/crates/makiatto/src/web/image.rs
@@ -326,3 +326,25 @@ impl std::fmt::Display for ProcessError {
 }
 
 impl std::error::Error for ProcessError {}
+
+#[cfg(test)]
+mod tests {
+    use super::ImageProcessor;
+
+    #[test]
+    fn detects_real_transform_params() {
+        assert!(ImageProcessor::has_transform_params("w=100"));
+        assert!(ImageProcessor::has_transform_params("h=100&fmt=webp"));
+        assert!(ImageProcessor::has_transform_params("fit=crop&q=80"));
+    }
+
+    #[test]
+    fn ignores_unrelated_params() {
+        // these contain "w=" / "h=" / "q=" as substrings but not as keys
+        assert!(!ImageProcessor::has_transform_params("new=1"));
+        assert!(!ImageProcessor::has_transform_params("show=true"));
+        assert!(!ImageProcessor::has_transform_params("query=foo"));
+        assert!(!ImageProcessor::has_transform_params(""));
+        assert!(!ImageProcessor::has_transform_params("foo=bar&baz=qux"));
+    }
+}

--- a/crates/makiatto/src/web/wasm.rs
+++ b/crates/makiatto/src/web/wasm.rs
@@ -15,6 +15,11 @@ use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 
 use crate::config::WasmConfig;
 
+/// Upper bound on the request/response body we will buffer in memory when
+/// running WASM functions and transforms. Prevents an oversized body from
+/// exhausting memory before any per-function size limit is applied.
+pub(crate) const MAX_WASM_BODY_BYTES: usize = 32 * 1024 * 1024; // 32 MiB
+
 pub mod http_bindings {
     wasmtime::component::bindgen!({
         world: "http",
@@ -152,7 +157,25 @@ fn is_private_or_reserved_ip(ip: IpAddr) -> bool {
                 // AWS/cloud metadata endpoints
                 || ipv4.octets() == [169, 254, 169, 254]
         }
-        IpAddr::V6(ipv6) => ipv6.is_loopback() || ipv6.is_unspecified() || ipv6.is_multicast(),
+        IpAddr::V6(ipv6) => {
+            // unwrap IPv4-mapped addresses (e.g. ::ffff:169.254.169.254) and run
+            // them through the IPv4 checks, otherwise the v4 ranges are bypassable
+            if let Some(v4) = ipv6.to_ipv4_mapped() {
+                return is_private_or_reserved_ip(IpAddr::V4(v4));
+            }
+
+            let segments = ipv6.segments();
+            // fc00::/7 unique-local and fe80::/10 link-local are not covered by
+            // the std loopback/unspecified/multicast checks
+            let is_unique_local = (segments[0] & 0xfe00) == 0xfc00;
+            let is_link_local = (segments[0] & 0xffc0) == 0xfe80;
+
+            ipv6.is_loopback()
+                || ipv6.is_unspecified()
+                || ipv6.is_multicast()
+                || is_unique_local
+                || is_link_local
+        }
     }
 }
 

--- a/crates/makiatto/src/web/wasm.rs
+++ b/crates/makiatto/src/web/wasm.rs
@@ -224,3 +224,46 @@ pub(crate) fn create_store_data(
         limits,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::is_private_or_reserved_ip;
+
+    fn blocked(ip: &str) -> bool {
+        is_private_or_reserved_ip(ip.parse().unwrap())
+    }
+
+    #[test]
+    fn blocks_private_and_reserved_ipv4() {
+        assert!(blocked("127.0.0.1"));
+        assert!(blocked("10.0.0.1"));
+        assert!(blocked("192.168.1.1"));
+        assert!(blocked("169.254.169.254")); // cloud metadata
+        assert!(blocked("0.0.0.0"));
+    }
+
+    #[test]
+    fn allows_public_ipv4() {
+        assert!(!blocked("8.8.8.8"));
+        assert!(!blocked("1.1.1.1"));
+    }
+
+    #[test]
+    fn blocks_ipv6_bypasses() {
+        // the bypasses the review specifically called out
+        assert!(blocked("::ffff:169.254.169.254")); // v4-mapped cloud metadata
+        assert!(blocked("::ffff:127.0.0.1")); // v4-mapped loopback
+        assert!(blocked("::ffff:10.0.0.1")); // v4-mapped private
+        assert!(blocked("fc00::1")); // unique-local
+        assert!(blocked("fd12:3456::1")); // unique-local
+        assert!(blocked("fe80::1")); // link-local
+        assert!(blocked("::1")); // loopback
+        assert!(blocked("::")); // unspecified
+    }
+
+    #[test]
+    fn allows_public_ipv6() {
+        assert!(!blocked("2606:4700:4700::1111")); // cloudflare
+        assert!(!blocked("2001:4860:4860::8888")); // google
+    }
+}

--- a/crates/makiatto/src/web/wasm/functions.rs
+++ b/crates/makiatto/src/web/wasm/functions.rs
@@ -70,7 +70,7 @@ pub async fn execute_function(
     let query = parts.uri.query().map(std::string::ToString::to_string);
     let headers = convert_headers(&parts.headers);
 
-    let body_bytes = axum::body::to_bytes(body, usize::MAX)
+    let body_bytes = axum::body::to_bytes(body, super::MAX_WASM_BODY_BYTES)
         .await
         .map_err(|e| miette!("Failed to read request body: {e}"))?;
     let body_vec = if body_bytes.is_empty() {
@@ -152,13 +152,13 @@ pub(crate) async fn wasm_function_middleware(
         return next.run(request).await;
     };
 
-    let (hostname, _port) = host
-        .split_once(':')
-        .map_or((host.as_str(), 80u16), |(hostname, port_str)| {
-            (hostname, port_str.parse::<u16>().unwrap_or(80))
-        });
+    let hostname = crate::util::host_without_port(&host);
 
     let resolved_domain = crate::web::axum::resolve_cname(&state.cname_map, hostname);
+
+    if !crate::util::is_safe_domain(&resolved_domain) {
+        return next.run(request).await;
+    }
 
     let request_path = request.uri().path();
     let method = request.method().clone();
@@ -211,7 +211,12 @@ pub(crate) async fn wasm_function_middleware(
     };
 
     let domain_dir = state.static_dir.join(&resolved_domain);
-    let wasm_path = domain_dir.join(&row.path);
+    // the wasm path comes from the replicated DB; contain it under the domain dir
+    let Ok(wasm_path) = crate::util::contained_path(&state.static_dir, &resolved_domain, &row.path)
+    else {
+        tracing::error!("Rejected unsafe wasm function path: {:?}", row.path);
+        return next.run(request).await;
+    };
 
     match std::panic::AssertUnwindSafe(execute_function(
         wasm_runtime,

--- a/crates/makiatto/src/web/wasm/transforms.rs
+++ b/crates/makiatto/src/web/wasm/transforms.rs
@@ -120,10 +120,12 @@ pub(crate) async fn wasm_transform_middleware(
         return next.run(request).await;
     };
 
-    let hostname = host
-        .split_once(':')
-        .map_or(host.as_str(), |(hostname, _)| hostname);
+    let hostname = crate::util::host_without_port(&host);
     let resolved_domain = crate::web::axum::resolve_cname(&state.cname_map, hostname);
+
+    if !crate::util::is_safe_domain(&resolved_domain) {
+        return next.run(request).await;
+    }
 
     let request_path = request.uri().path().to_string();
 
@@ -194,10 +196,10 @@ pub(crate) async fn wasm_transform_middleware(
 
     let (mut parts, body) = response.into_parts();
 
-    let body_bytes = match axum::body::to_bytes(body, usize::MAX).await {
+    let body_bytes = match axum::body::to_bytes(body, super::MAX_WASM_BODY_BYTES).await {
         Ok(bytes) => bytes,
         Err(e) => {
-            tracing::error!("Failed to read response body: {e}");
+            tracing::error!("Failed to read response body for transform: {e}");
             return (parts, Body::empty()).into_response();
         }
     };
@@ -214,7 +216,13 @@ pub(crate) async fn wasm_transform_middleware(
     let domain_dir = state.static_dir.join(&resolved_domain);
 
     for transform in matching_transforms {
-        let wasm_path = domain_dir.join(&transform.path);
+        // the transform path comes from the replicated DB; contain it
+        let Ok(wasm_path) =
+            crate::util::contained_path(&state.static_dir, &resolved_domain, &transform.path)
+        else {
+            tracing::error!("Rejected unsafe wasm transform path: {:?}", transform.path);
+            continue;
+        };
 
         let transform_with_path = DomainTransform {
             path: wasm_path.to_string_lossy().to_string(),

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -47,3 +47,17 @@ For traditional server-side applications (databases, WebSockets, long-running pr
 ## Can I mix different hosting providers?
 
 Yes! Since nodes communicate via WireGuard mesh over the public internet, you can mix any providers (AWS, DigitalOcean, Hetzner, Vultr, bare metal servers, etc.) as long as they have public IP addresses and allow WireGuard traffic.
+
+## `maki` fails with "SSH host key mismatch" — what do I do?
+
+`maki` verifies each node's SSH host key against your `~/.ssh/known_hosts` before authenticating, so the sudo password and WireGuard private key are never handed to an impersonated host. The first time you connect to a node its key is recorded automatically (trust on first use); after that, a changed key aborts the connection with a mismatch error.
+
+If you see this error, it usually means one of:
+
+- **The host key legitimately changed** — e.g. you rebuilt or reprovisioned the server, or its IP/port was reused for a different machine. Remove the stale entry and reconnect (which records the new key):
+  ```sh
+  ssh-keygen -R "[host]:port"   # use plain "host" if the node uses port 22
+  ```
+- **Something is intercepting the connection** — if you did *not* expect the key to change, treat it as a potential machine-in-the-middle and investigate before reconnecting.
+
+You can point `maki` at a different known_hosts file by setting the `MAKIATTO_KNOWN_HOSTS` environment variable.

--- a/tests/src/e2e.rs
+++ b/tests/src/e2e.rs
@@ -1,2 +1,3 @@
 mod provision;
+mod ssh;
 mod sync;

--- a/tests/src/e2e/provision.rs
+++ b/tests/src/e2e/provision.rs
@@ -9,7 +9,7 @@ async fn test_provision_first() -> Result<()> {
     let mut context = ContainerContext::new()?;
 
     let TestContainer {
-        container: _base_container,
+        container: base_container,
         ports: PortMap { ssh, .. },
         ..
     } = context.make_base().await?;
@@ -29,6 +29,21 @@ async fn test_provision_first() -> Result<()> {
 
     makiatto_cli::machine::init_machine(&request, &mut config)?;
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    // provisioning must install a *constrained* sudoers rule for the daemon —
+    // only the `ip` subcommands it needs, never blanket chmod/chown/mkdir/etc.
+    let base = base_container.expect("No base container");
+    let (sudoers, _) = util::execute_command(&base, "cat /etc/sudoers.d/makiatto").await?;
+    assert!(
+        sudoers.contains("ip route add") && sudoers.contains("ip link set"),
+        "sudoers rule missing expected ip grants: {sudoers}"
+    );
+    for forbidden in ["chmod", "chown", "mkdir", "setcap", "systemctl"] {
+        assert!(
+            !sudoers.contains(forbidden),
+            "sudoers rule must not grant unconstrained {forbidden}: {sudoers}"
+        );
+    }
 
     Ok(())
 }

--- a/tests/src/e2e/ssh.rs
+++ b/tests/src/e2e/ssh.rs
@@ -1,0 +1,75 @@
+#![cfg(test)]
+use miette::{IntoDiagnostic, Result};
+
+use crate::container::{ContainerContext, PortMap, TestContainer};
+
+/// Corrupt the key blob of each `known_hosts` line so the stored key no longer
+/// matches the server's real host key, while keeping each entry well-formed
+/// (same field layout, same base64 length).
+fn corrupt_known_hosts(content: &str) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    for line in content.lines() {
+        let fields: Vec<&str> = line.splitn(3, ' ').collect();
+        if fields.len() == 3 {
+            let mut blob: Vec<char> = fields[2].chars().collect();
+            // flip a character in the middle of the base64 key material: changes
+            // the decoded bytes without disturbing the type framing or padding
+            let idx = blob.len() / 2;
+            blob[idx] = if blob[idx] == 'A' { 'B' } else { 'A' };
+            let blob: String = blob.into_iter().collect();
+            lines.push(format!("{} {} {}", fields[0], fields[1], blob));
+        } else {
+            lines.push(line.to_string());
+        }
+    }
+    let mut out = lines.join("\n");
+    out.push('\n');
+    out
+}
+
+/// A connection whose recorded host key no longer matches the server's key must
+/// be rejected (potential machine-in-the-middle), rather than silently trusted.
+#[tokio::test]
+async fn test_ssh_host_key_mismatch_is_rejected() -> Result<()> {
+    let mut context = ContainerContext::new()?;
+
+    let TestContainer {
+        ports: PortMap { ssh, .. },
+        ..
+    } = context.make_base().await?;
+
+    // isolate known_hosts to a temp file for this test
+    let kh_dir = std::env::temp_dir().join(format!("maki-kh-{}", uuid::Uuid::now_v7()));
+    std::fs::create_dir_all(&kh_dir).into_diagnostic()?;
+    let kh_path = kh_dir.join("known_hosts");
+    // SAFETY: nextest runs each test in its own process, so mutating the
+    // environment here does not race other tests.
+    unsafe { std::env::set_var("MAKIATTO_KNOWN_HOSTS", &kh_path) };
+
+    let key = context.root.join("tests/fixtures/.ssh/id_ed25519");
+
+    // first connect records the host key (trust on first use)
+    makiatto_cli::ssh::SshSession::new("root@localhost", Some(ssh), Some(&key))?;
+
+    let recorded = std::fs::read_to_string(&kh_path).into_diagnostic()?;
+    assert!(
+        !recorded.trim().is_empty(),
+        "TOFU did not record a host key on first connect"
+    );
+
+    // tamper with the stored key, then reconnect — must be rejected
+    std::fs::write(&kh_path, corrupt_known_hosts(&recorded)).into_diagnostic()?;
+
+    let result = makiatto_cli::ssh::SshSession::new("root@localhost", Some(ssh), Some(&key));
+
+    // SAFETY: see above.
+    unsafe { std::env::remove_var("MAKIATTO_KNOWN_HOSTS") };
+    std::fs::remove_dir_all(&kh_dir).ok();
+
+    assert!(
+        result.is_err(),
+        "expected a changed host key to be rejected, but the connection succeeded"
+    );
+
+    Ok(())
+}

--- a/tests/src/integration/certificate.rs
+++ b/tests/src/integration/certificate.rs
@@ -199,7 +199,7 @@ async fn test_certificate_replacement() -> Result<()> {
         &format!("SELECT COUNT(*) FROM certificates WHERE domain = '{domain}';"),
     )
     .await?;
-    assert!(output.trim() == "1");
+    assert_eq!(output.trim(), "1");
 
     // replace with new certificate (longer expiry)
     let new_expires_at = util::current_timestamp() + (90 * 86400); // 90 days

--- a/tests/src/integration/wasm.rs
+++ b/tests/src/integration/wasm.rs
@@ -67,7 +67,15 @@ async fn test_wasm_function_basic_execution() -> Result<()> {
 
     let status = response.status();
     let body = response.text().await.into_diagnostic()?;
-    assert_eq!(status, 200, "GET returned {status}; body: {body}");
+    if status != 200 {
+        let (ls, _) = util::execute_command(
+            &daemon,
+            "ls -la /var/makiatto/sites/localhost/api/ 2>&1; echo '--- storage ---'; ls -la /var/makiatto/storage/ 2>&1; echo '--- stat ---'; stat /var/makiatto/sites/localhost/api/hello.wasm 2>&1; echo '--- files row ---'; sudo -u makiatto sqlite3 /var/makiatto/cluster.db 'SELECT domain,path,content_hash FROM files;' 2>&1",
+        )
+        .await
+        .unwrap_or_default();
+        panic!("GET returned {status}; body: {body}\nFS STATE:\n{ls}");
+    }
     assert!(body.contains("Method::Get"), "unexpected body: {body}");
     assert!(body.contains("Path: /api/hello"), "unexpected body: {body}");
 

--- a/tests/src/integration/wasm.rs
+++ b/tests/src/integration/wasm.rs
@@ -65,11 +65,11 @@ async fn test_wasm_function_basic_execution() -> Result<()> {
         .await
         .into_diagnostic()?;
 
-    assert_eq!(response.status(), 200);
-
+    let status = response.status();
     let body = response.text().await.into_diagnostic()?;
-    assert!(body.contains("Method::Get"));
-    assert!(body.contains("Path: /api/hello"));
+    assert_eq!(status, 200, "GET returned {status}; body: {body}");
+    assert!(body.contains("Method::Get"), "unexpected body: {body}");
+    assert!(body.contains("Path: /api/hello"), "unexpected body: {body}");
 
     // Test POST request
     let post_response = reqwest::Client::new()

--- a/tests/src/integration/wasm.rs
+++ b/tests/src/integration/wasm.rs
@@ -67,15 +67,7 @@ async fn test_wasm_function_basic_execution() -> Result<()> {
 
     let status = response.status();
     let body = response.text().await.into_diagnostic()?;
-    if status != 200 {
-        let (ls, _) = util::execute_command(
-            &daemon,
-            "ls -la /var/makiatto/sites/localhost/api/ 2>&1; echo '--- storage ---'; ls -la /var/makiatto/storage/ 2>&1; echo '--- stat ---'; stat /var/makiatto/sites/localhost/api/hello.wasm 2>&1; echo '--- files row ---'; sudo -u makiatto sqlite3 /var/makiatto/cluster.db 'SELECT domain,path,content_hash FROM files;' 2>&1",
-        )
-        .await
-        .unwrap_or_default();
-        panic!("GET returned {status}; body: {body}\nFS STATE:\n{ls}");
-    }
+    assert_eq!(status, 200, "GET returned {status}; body: {body}");
     assert!(body.contains("Method::Get"), "unexpected body: {body}");
     assert!(body.contains("Path: /api/hello"), "unexpected body: {body}");
 


### PR DESCRIPTION
Addresses the whole-codebase defensive review (`makiatto-code-review.md`). The recurring weakness was that untrusted input — the public internet (HTTP/DNS), peer-replicated Corrosion data, and strings interpolated into remote shell/SQL — was trusted at every boundary. This PR closes those gaps.

## Critical
- **C1** DNS query with no question section now returns FORMERR instead of unwrapping (`web/dns.rs`).
- **C2** `Host` header parsed without panicking on malformed/IPv6/odd-port values.
- **C3** Path traversal via `Host`/URI closed: resolved domain is validated and file paths are contained under the content root for both static and image serving.
- **C4** Peer-replicated `domain`/`path` joins are contained via a shared `util::contained_path` helper (with unit tests).
- **C5** Every Corrosion write now goes through parameterised statements (a new `Statement` type in both crates) instead of `format!`-built SQL.
- **C6** The CLI sends transaction payloads to `curl` on stdin via a single-quoted heredoc, eliminating remote shell injection; SQL is parameterised so values can't break out either.

## High
- **H1** IPv6 SSRF bypass closed (v4-mapped, unique-local `fc00::/7`, link-local `fe80::/10`).
- **H2** DNS record rendering skips malformed DB values instead of panicking.
- **H3** TOFU SSH host-key verification against `~/.ssh/known_hosts` before authentication.
- **H4 / M12** Leader election tie-breaks on actor id, re-verifies after a convergence delay, and applies a clock-skew margin to lease expiry.
- **H5** `/etc/makiatto.toml` is `chmod 600` and removed (with the sudoers file) on machine removal.
- **H6** The `makiatto` NOPASSWD sudoers rule is constrained to the specific `ip` commands the daemon needs.

## Medium
M1 (bounded body buffering + `DefaultBodyLimit` + WASM body caps), M2 (`spawn_blocking` + source-size cap for imageflow), M3 (lat/lon swap in geo-routing), M4 (atomic content-store writes), M5 (no deletions during startup reconciliation), M6 (await graceful shutdown on signal), M7 (reset subscription backoff, lower cap), M8 (`select_all` supervision), M9 (health check no longer panics on SSH failure), M10 (scope guard resumes the watcher), M11 (poll for ACME challenge visibility + delete after issuance), M13 (ignore forwarded host headers by default, config-gated).

## Low
GeoLite download validated + atomic; metric key/geolite-task fixes; EXDEV-safe hardlink replace; blocking fs calls moved off the async path; reflected host removed from 404 body; unencrypted cert key documented; deterministic default SNI cert; `env_file` wired into sync; `build.rs` rerun-if-changed; `get_peers` doc; N+1 query removed; cache temp-file race; consistent `sudo -u makiatto` DB reads; ipify IP validation; container detection in release builds; SSH port/IPv6 parsing; `exec_stream` raw-mode ordering; ACME account reuse.

## Testing
- `cargo clippy -p makiatto -p makiatto-cli` — clean.
- `cargo test -p makiatto -p makiatto-cli --lib --bins` — all pass (incl. new `contained_path` and `parse_ssh_target` tests).
- `cargo test --workspace --no-run` — all targets compile.
- Container/e2e tests were not run locally; CI will exercise them.